### PR TITLE
changed kernel to use 'read_only_data' (otherwise never used)

### DIFF
--- a/samples/Ch06_unified_shared_memory/fig_6_8_prefetch_memadvise.cpp
+++ b/samples/Ch06_unified_shared_memory/fig_6_8_prefetch_memadvise.cpp
@@ -28,7 +28,7 @@ int main() {
 
   for (int b = 0; b < NUM_BLOCKS; b++) {
     Q.parallel_for(range{BLOCK_SIZE}, e,
-                   [=](id<1> i) { data[b * BLOCK_SIZE + i] += data[i]; });
+                   [=](id<1> i) { data[b * BLOCK_SIZE + i] += read_only_data[i]; });
     if ((b + 1) < NUM_BLOCKS) {
       // Prefetch next block
       e = Q.prefetch(data + (b + 1) * BLOCK_SIZE, BLOCK_SIZE);


### PR DESCRIPTION
On page 167 in figure 6-8: you create the read_only_data array, initialize it, and explicitly tell the runtime that this array is read-only used in the kernel (using the mem_advise function). However, in the example code (as well as in the code samples) you never access the read_only_data array in the kernel (which, hence, is never used). I guess the kernel instead of being
```
Q.parallel_for(range{BLOCK_SIZE}, e, [=](id<1> i) {
    data[b * BLOCK_SIZE + i] += data[i];
});
```
should be
```
Q.parallel_for(range{BLOCK_SIZE}, e, [=](id<1> i) {
    data[b * BLOCK_SIZE + i] += read_only_data[i];
});
```