### PR TITLE
Changed data type of 'triad_bytes' from int to size_t to prevent an integer overflow

### DIFF
--- a/samples/Ch16_cpus/fig_16_6_stream_triad.cpp
+++ b/samples/Ch16_cpus/fig_16_6_stream_triad.cpp
@@ -80,7 +80,7 @@ int main(int argc, char *argv[]) {
   }
   std::cout << "Results are correct!\n\n";
 
-  int triad_bytes = 3 * sizeof(double) * array_size;
+  size_t triad_bytes = 3 * sizeof(double) * array_size;
   std::cout << "Triad Bytes: " << triad_bytes << "\n";
   std::cout << "Time in sec (fastest run): " << min_time * 1.0E-9 << "\n";
 


### PR DESCRIPTION
In the code sample for figure 16-5: the number of loaded bytes for the vector triad is saved as `int`. This causes an integer overflow (resulting in a negative bandwidth) when entering an `array_size` larger than `89'478'485`. However, I had to use an `array_size` of `100'000'000` to get representative runtimes (~0.15s). Changing the type of the `triad_byte` variable to `std::size_t` should fix this issue.