### PR TITLE
Update fpga_extensions.hpp location

### DIFF
--- a/samples/Ch02_where_code_runs/fig_2_12_multiple_selectors.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_12_multiple_selectors.cpp
@@ -1,9 +1,9 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 
 // SPDX-License-Identifier: MIT
 
 #include <CL/sycl.hpp>
-#include <CL/sycl/INTEL/fpga_extensions.hpp> // For fpga_selector
+#include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_selector
 #include <iostream>
 #include <string>
 using namespace sycl;
@@ -21,7 +21,7 @@ int main() {
   output_dev_info( device{ cpu_selector{}}, "cpu_selector" );
   output_dev_info( device{ gpu_selector{}}, "gpu_selector" );
   output_dev_info( device{ accelerator_selector{}}, "accelerator_selector" );
-  output_dev_info( device{ INTEL::fpga_selector{}}, "fpga_selector" );
+  output_dev_info( device{ ext::intel::fpga_selector{}}, "fpga_selector" );
 
   return 0;
 }

--- a/samples/Ch02_where_code_runs/fig_2_13_gpu_plus_fpga.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_13_gpu_plus_fpga.cpp
@@ -1,15 +1,15 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 
 // SPDX-License-Identifier: MIT
 
 #include <CL/sycl.hpp>
-#include <CL/sycl/INTEL/fpga_extensions.hpp> // For fpga_selector
+#include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_selector
 #include <iostream>
 using namespace sycl;
 
 int main() {
   queue my_gpu_queue( gpu_selector{} );
-  queue my_fpga_queue( INTEL::fpga_selector{} );
+  queue my_fpga_queue( ext::intel::fpga_selector{} );
 
   std::cout << "Selected device 1: " <<
     my_gpu_queue.get_device().get_info<info::device::name>() << "\n";

--- a/samples/Ch17_fpgas/fig_17_11_fpga_emulator_selector.cpp
+++ b/samples/Ch17_fpgas/fig_17_11_fpga_emulator_selector.cpp
@@ -1,9 +1,9 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 
 // SPDX-License-Identifier: MIT
 
 #include <CL/sycl.hpp>
-#include <CL/sycl/INTEL/fpga_extensions.hpp> // For fpga_selector
+#include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_selector
 using namespace sycl;
 
 void say_device(const queue& Q) {
@@ -12,7 +12,7 @@ void say_device(const queue& Q) {
 }
 
 int main() {
-  queue Q{ INTEL::fpga_emulator_selector{} };
+  queue Q{ ext::intel::fpga_emulator_selector{} };
   say_device(Q);
 
   Q.submit([&](handler &h){

--- a/samples/Ch17_fpgas/fig_17_17_ndrange_func.cpp
+++ b/samples/Ch17_fpgas/fig_17_17_ndrange_func.cpp
@@ -1,9 +1,9 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 
 // SPDX-License-Identifier: MIT
 
 #include <CL/sycl.hpp>
-#include <CL/sycl/INTEL/fpga_extensions.hpp> // For fpga_selector
+#include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_emulator_selector
 using namespace sycl;
 
 int generate_random_number_from_ID(const id<3>& I) {
@@ -11,7 +11,7 @@ int generate_random_number_from_ID(const id<3>& I) {
 };
 
 int main() {
-  queue Q{ INTEL::fpga_emulator_selector{} };
+  queue Q{ ext::intel::fpga_emulator_selector{} };
 
   buffer <int,3> B{ range{16,16,16} };
 

--- a/samples/Ch17_fpgas/fig_17_18_loop_func.cpp
+++ b/samples/Ch17_fpgas/fig_17_18_loop_func.cpp
@@ -1,9 +1,9 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 
 // SPDX-License-Identifier: MIT
 
 #include <CL/sycl.hpp>
-#include <CL/sycl/INTEL/fpga_extensions.hpp> // For fpga_selector
+#include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_emulator_selector
 using namespace sycl;
 
 int generate_random_number(const int& state) {
@@ -12,7 +12,7 @@ int generate_random_number(const int& state) {
 
 int main() {
   constexpr int size = 64; 
-  queue Q{ INTEL::fpga_emulator_selector{} };
+  queue Q{ ext::intel::fpga_emulator_selector{} };
 
   buffer <int> B{ range{size} };
 

--- a/samples/Ch17_fpgas/fig_17_20_loop_carried_deps.cpp
+++ b/samples/Ch17_fpgas/fig_17_20_loop_carried_deps.cpp
@@ -1,9 +1,9 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 
 // SPDX-License-Identifier: MIT
 
 #include <CL/sycl.hpp>
-#include <CL/sycl/INTEL/fpga_extensions.hpp> // For fpga_selector
+#include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_emulator_selector
 using namespace sycl;
 
 int generate_random_number(const int& state) {
@@ -12,7 +12,7 @@ int generate_random_number(const int& state) {
 
 int main() {
   constexpr int size = 64; 
-  queue Q{ INTEL::fpga_emulator_selector{} };
+  queue Q{ ext::intel::fpga_emulator_selector{} };
 
   buffer <int> B{ range{size} };
 

--- a/samples/Ch17_fpgas/fig_17_22_loop_carried_state.cpp
+++ b/samples/Ch17_fpgas/fig_17_22_loop_carried_state.cpp
@@ -1,9 +1,9 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 
 // SPDX-License-Identifier: MIT
 
 #include <CL/sycl.hpp>
-#include <CL/sycl/INTEL/fpga_extensions.hpp> // For fpga_selector
+#include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_emulator_selector
 using namespace sycl;
 
 int generate_incremental_random_number(const int& state) {
@@ -14,7 +14,7 @@ int main() {
   constexpr int size = 64; 
   constexpr int seed = 0; 
 
-  queue Q{ INTEL::fpga_emulator_selector{} };
+  queue Q{ ext::intel::fpga_emulator_selector{} };
 
   buffer <int> B{ range{size} };
 

--- a/samples/Ch17_fpgas/fig_17_31_inter_kernel_pipe.cpp
+++ b/samples/Ch17_fpgas/fig_17_31_inter_kernel_pipe.cpp
@@ -1,9 +1,9 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 
 // SPDX-License-Identifier: MIT
 
 #include <CL/sycl.hpp>
-#include <CL/sycl/INTEL/fpga_extensions.hpp> // For fpga_selector
+#include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_emulator_selector
 #include <array>
 using namespace sycl;
 
@@ -21,7 +21,7 @@ int main() {
   buffer <int> B_out{ range{count} };
 
   // Acquire queue to emulated FPGA device
-  queue Q{ INTEL::fpga_emulator_selector{} };
+  queue Q{ ext::intel::fpga_emulator_selector{} };
 
 // BEGIN CODE SNIP
   // Create alias for pipe type so that consistent across uses

--- a/samples/Ch17_fpgas/fig_17_9_fpga_selector.cpp
+++ b/samples/Ch17_fpgas/fig_17_9_fpga_selector.cpp
@@ -1,9 +1,9 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 
 // SPDX-License-Identifier: MIT
 
 #include <CL/sycl.hpp>
-#include <CL/sycl/INTEL/fpga_extensions.hpp> // For fpga_selector
+#include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_selector
 using namespace sycl;
 
 void say_device(const queue& Q) {
@@ -12,7 +12,7 @@ void say_device(const queue& Q) {
 }
 
 int main() {
-  queue Q{ INTEL::fpga_selector{} };
+  queue Q{ ext::intel::fpga_selector{} };
   say_device(Q);
 
   Q.submit([&](handler &h){


### PR DESCRIPTION
Upcoming dpcpp compiler release introduces the removal of previously
deprecated `CL/sycl/INTEL/...` and `CL/sycl/ONEAPI/...` headers. This
patch replaces the locations of such headers with the new ones: with
`sycl/ext/intel/...` and `sycl/ext/oneapi/...`