### PR TITLE
Update samples to use SYCL 2020 APIs

### DIFF
--- a/samples/Ch10_expressing_kernels/fig_10_7_opencl_source_interop.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_7_opencl_source_interop.cpp
@@ -2,7 +2,9 @@
 
 // SPDX-License-Identifier: MIT
 
+#include <CL/cl.h>
 #include <CL/sycl.hpp>
+#include <CL/sycl/backend/opencl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -22,14 +24,28 @@ int main() {
     // Note: This must select a device that supports interop!
     queue Q{ cpu_selector{} };
 
-    program p{Q.get_context()};
-    p.build_with_source(R"CLC(
+    cl_context OCLContext = get_native<backend::opencl>(Q.get_context());
+    cl_device_id OCLDeviceID = get_native<backend::opencl>(Q.get_device());
+
+    const std::string Source = R"CLC(
             kernel void add(global int* data) {
                 int index = get_global_id(0);
                 data[index] = data[index] + 1;
             }
-        )CLC",
-        "-cl-fast-relaxed-math");
+        )CLC";
+
+    const char *SourceStr = Source.c_str();
+    const size_t SourceSize = Source.size();
+
+    cl_int Ret;
+    cl_program OCLProgram =
+        clCreateProgramWithSource(OCLContext, 1, &SourceStr, &SourceSize, &Ret);
+    Ret = clBuildProgram(OCLProgram, 1, &OCLDeviceID, "-cl-fast-relaxed-math",
+                         nullptr, nullptr);
+    cl_kernel OCLKernel = clCreateKernel(OCLProgram, "add", &Ret);
+
+    kernel SYCLKernel =
+        make_kernel<backend::opencl>(OCLKernel, Q.get_context());
 
     std::cout << "Running on device: "
               << Q.get_device().get_info<info::device::name>() << "\n";
@@ -38,9 +54,13 @@ int main() {
       accessor data_acc {data_buf, h};
 
       h.set_args(data_acc);
-      h.parallel_for(size, p.get_kernel("add"));
+      h.parallel_for(size, SYCLKernel);
     });
-// END CODE SNIP
+
+    clReleaseKernel(OCLKernel);
+    clReleaseProgram(OCLProgram);
+    clReleaseContext(OCLContext);
+    // END CODE SNIP
   }
 
   for (int i = 0; i < size; i++) {

--- a/samples/Ch10_expressing_kernels/fig_10_8_opencl_object_interop.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_8_opencl_object_interop.cpp
@@ -2,7 +2,9 @@
 
 // SPDX-License-Identifier: MIT
 
+#include <CL/cl.h>
 #include <CL/sycl.hpp>
+#include <CL/sycl/backend/opencl.hpp>
 #include <iostream>
 using namespace sycl;
 
@@ -30,7 +32,7 @@ int main() {
                 data[index] = data[index] + 1;
             }
         )CLC";
-    cl_context c = sc.get();
+    cl_context c = get_native<backend::opencl>(sc);
     cl_program p =
         clCreateProgramWithSource(c, 1, &kernelSource, nullptr, nullptr);
     clBuildProgram(p, 0, nullptr, nullptr, nullptr, nullptr);
@@ -39,11 +41,13 @@ int main() {
     std::cout << "Running on device: "
               << Q.get_device().get_info<info::device::name>() << "\n";
 
+    kernel sk = make_kernel<backend::opencl>(k, sc);
+
     Q.submit([&](handler& h) {
       accessor data_acc{data_buf, h};
 
       h.set_args(data_acc);
-      h.parallel_for(size, kernel{k, sc});
+      h.parallel_for(size, sk);
     });
 
     clReleaseContext(c);

--- a/samples/Ch10_expressing_kernels/fig_10_9_kernel_lambda_build_options.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_9_kernel_lambda_build_options.cpp
@@ -25,22 +25,17 @@ int main() {
               << Q.get_device().get_info<info::device::name>() << "\n";
 
 // BEGIN CODE SNIP
-    // This compiles the kernel named by the specified template
-    // parameter using the "fast relaxed math" build option.
-    program p(Q.get_context());
-
-    p.build_with_kernel_type<class Add>("-cl-fast-relaxed-math");
+    kernel_id AddID = get_kernel_id<class Add>();
+    auto KernelBundle =
+        get_kernel_bundle<bundle_state::executable>(Q.get_context(), {AddID});
+    kernel Kernel = KernelBundle.get_kernel(AddID);
 
     Q.submit([&](handler& h) {
       accessor data_acc {data_buf, h};
 
       h.parallel_for<class Add>(
           // This uses the previously compiled kernel.
-          p.get_kernel<class Add>(),
-          range{size},
-          [=](id<1> i) {
-            data_acc[i] = data_acc[i] + 1;
-          });
+          Kernel, range{size}, [=](id<1> i) { data_acc[i] = data_acc[i] + 1; });
     });
 // END CODE SNIP
   }


### PR DESCRIPTION
Some APIs have been removed from SYCL 2020. This Pull Request replaces usages of removed interop API and program API with the closest SYCL 2020 alternative.