### PR TITLE
add book errata for misleading Figure 15-13

### DIFF
--- a/book_errata.txt
+++ b/book_errata.txt
@@ -31,6 +31,8 @@ p.319 - translational unit -> translation unit
 
 p.330 - A scan is said to be exclusive... the range [0, i] -> range [0, i)
 
+p.368 - Figure 15-13: the rightmost "Op" box should be moved to the right since it cannot overlap the bottommost "Long Operation" box
+
 p.373 - it may preferable to save trasnfer costs -> it may be preferable...
 
 p.414 - Figure 16-17: get_globalid(0) -> get_global_id(0)


### PR DESCRIPTION
In Figure 15-13, the rightmost "Op" box should be moved to the right since it cannot overlap the bottommost "Long Operation" box.