### PR TITLE
Errata in code output for Fig 2-7 and Fig 2-9

### DIFF
--- a/book_errata.txt
+++ b/book_errata.txt
@@ -2,6 +2,17 @@ The following are known errors in the book Data Parallel C++: Mastering DPC++ fo
 Programming of Heterogeneous Systems using C++ and SYCL by James Reinders, Ben Ashbaugh,
 James Brodman, Michael Kinsner, John Pennycook, Xinmin Tian (Apress, 2020).
 
+p.35 - Fig 2-7 - Output of code:
+Device: SYCL host device
+should read
+Selected device: SYCL host device
+
+p.37 - Fig 2-9 - Output of code:
+Device: SYCL host device
+should read
+Selected device: SYCL host device
+Device vendor:
+
 p.106 - Fig 4-11 - Comment in code:
 // Return the offset of this item (if with_offset == true)
 should read:


### PR DESCRIPTION
Signed-off-by: Dan Holmes <daniel.john.holmes@intel.com>

The possible code output given in Figures 2-7 and 2-9 are not possible. This PR corrects the output.