### PR TITLE
Relax correctness test for Ch04 matrix multiply

### DIFF
--- a/samples/Ch04_expressing_parallelism/fig_4_13_nd_range_matrix_multiply.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_13_nd_range_matrix_multiply.cpp
@@ -59,7 +59,7 @@ int main() {
       for (int k = 0; k < N; ++k) {
         gold += a[j * N + k] * b[k * N + i];
       }
-      if (std::abs(gold - c[j * N + i]) / gold > 1.0E-06) {
+      if (std::abs(gold - c[j * N + i]) / gold > 1.0E-05) {
         passed = false;
       }
     }

--- a/samples/Ch04_expressing_parallelism/fig_4_20_hierarchical_matrix_multiply.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_20_hierarchical_matrix_multiply.cpp
@@ -62,7 +62,7 @@ int main() {
       for (int k = 0; k < N; ++k) {
         gold += a[j * N + k] * b[k * N + i];
       }
-      if (std::abs(gold - c[j * N + i]) / gold > 1.0E-06) {
+      if (std::abs(gold - c[j * N + i]) / gold > 1.0E-05) {
         passed = false;
       }
     }

--- a/samples/Ch04_expressing_parallelism/fig_4_22_hierarchical_logical_matrix_multiply.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_22_hierarchical_logical_matrix_multiply.cpp
@@ -62,7 +62,7 @@ int main() {
       for (int k = 0; k < N; ++k) {
         gold += a[j * N + k] * b[k * N + i];
       }
-      if (std::abs(gold - c[j * N + i]) / gold > 1.0E-06) {
+      if (std::abs(gold - c[j * N + i]) / gold > 1.0E-05) {
         passed = false;
       }
     }

--- a/samples/Ch04_expressing_parallelism/fig_4_7_basic_matrix_multiply.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_7_basic_matrix_multiply.cpp
@@ -55,7 +55,7 @@ int main() {
       for (int k = 0; k < N; ++k) {
         gold += a[j * N + k] * b[k * N + i];
       }
-      if (std::abs(gold - c[j * N + i]) / gold > 1.0E-06) {
+      if (std::abs(gold - c[j * N + i]) / gold > 1.0E-05) {
         passed = false;
       }
     }


### PR DESCRIPTION
The error accumulates for each row of the matrix, so some implementations do
not pass with an epsilon of 1.0E-06 when using fast math optimizations.

Since the purpose of this sample is to demonstrate usage of SYCL rather than to
teach how to write rigorous tests for matrix multiplications, this commit
simply relaxes the correctness test by using a larger epsilon.