### PR TITLE
Switch to SYCL 2020 group operations and fix deprecation warnings

### DIFF
--- a/samples/Ch04_expressing_parallelism/fig_4_20_hierarchical_matrix_multiply.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_20_hierarchical_matrix_multiply.cpp
@@ -40,8 +40,8 @@ int main() {
       range num_groups{N / B, N / B}; // N is a multiple of B
       range group_size{B, B};
       h.parallel_for_work_group(num_groups, group_size, [=](group<2> grp) {
-        int jb = grp.get_id(0);
-        int ib = grp.get_id(1);
+        int jb = grp.get_group_id(0);
+        int ib = grp.get_group_id(1);
         grp.parallel_for_work_item([&](h_item<2> it) {
           int j = jb * B + it.get_local_id(0);
           int i = ib * B + it.get_local_id(1);

--- a/samples/Ch04_expressing_parallelism/fig_4_22_hierarchical_logical_matrix_multiply.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_22_hierarchical_logical_matrix_multiply.cpp
@@ -40,8 +40,8 @@ int main() {
       range num_groups{N / B, N / B}; // N is a multiple of B
       range group_size{B, B};
       h.parallel_for_work_group(num_groups, [=](group<2> grp) {
-        int jb = grp.get_id(0);
-        int ib = grp.get_id(1);
+        int jb = grp.get_group_id(0);
+        int ib = grp.get_group_id(1);
         grp.parallel_for_work_item(group_size, [&](h_item<2> it) {
           int j = jb * B + it.get_logical_local_id(0);
           int i = ib * B + it.get_logical_local_id(1);

--- a/samples/Ch06_unified_shared_memory/fig_6_8_prefetch_memadvise.cpp
+++ b/samples/Ch06_unified_shared_memory/fig_6_8_prefetch_memadvise.cpp
@@ -23,7 +23,7 @@ int main() {
   // to the device instead of migrating it from the host.
   // Real values will be documented by your DPC++ backend.
   int HW_SPECIFIC_ADVICE_RO = 0;
-  Q.mem_advise(read_only_data, BLOCK_SIZE,(pi_mem_advice)HW_SPECIFIC_ADVICE_RO);
+  Q.mem_advise(read_only_data, BLOCK_SIZE, HW_SPECIFIC_ADVICE_RO);
   event e = Q.prefetch(data, BLOCK_SIZE);
 
   for (int b = 0; b < NUM_BLOCKS; b++) {

--- a/samples/Ch07_buffers/fig_7_10_accessors.cpp
+++ b/samples/Ch07_buffers/fig_7_10_accessors.cpp
@@ -18,9 +18,9 @@ int main() {
   accessor pC{C};
 
   Q.submit([&](handler &h) {
-      accessor aA{A, h, write_only, noinit};
-      accessor aB{B, h, write_only, noinit};
-      accessor aC{C, h, write_only, noinit};
+      accessor aA{A, h, write_only, no_init};
+      accessor aB{B, h, write_only, no_init};
+      accessor aC{C, h, write_only, no_init};
       h.parallel_for(N, [=](id<1> i) {
           aA[i] = 1;
           aB[i] = 40;

--- a/samples/Ch09_work_item_communication/fig_9_11_sub_group_barrier.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_11_sub_group_barrier.cpp
@@ -28,7 +28,7 @@ int main() {
       h.parallel_for(nd_range{{size}, {16}}, [=](nd_item<1> item) {
         auto sg = item.get_sub_group();
         auto index = item.get_global_id();
-        sg.barrier();
+        group_barrier(sg);
         data_acc[index] = data_acc[index] + 1;
       });
 // END CODE SNIP

--- a/samples/Ch09_work_item_communication/fig_9_13_matmul_broadcast.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_13_matmul_broadcast.cpp
@@ -62,7 +62,7 @@ double run_sycl(
               // to ensure all work-items have a consistent view
               // of the matrix tile in local memory.
               tileA[i] = matrixA[m][kk + i];
-              item.barrier();
+              group_barrier(item.get_group());
 
               // Perform computation using the local memory tile, and
               // matrix B in global memory.
@@ -75,7 +75,7 @@ double run_sycl(
 
               // After computation, synchronize again, to ensure all
               // reads from the local memory tile are complete.
-              item.barrier();
+              group_barrier(item.get_group());
             }
 
             // Write the final result to global memory.

--- a/samples/Ch09_work_item_communication/fig_9_8_ndrange_tiled_matmul.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_8_ndrange_tiled_matmul.cpp
@@ -62,7 +62,7 @@ double run_sycl(
               // to ensure all work-items have a consistent view
               // of the matrix tile in local memory.
               tileA[i] = matrixA[m][kk + i];
-              item.barrier();
+              group_barrier(item.get_group());
 
               // Perform computation using the local memory tile, and
               // matrix B in global memory.
@@ -72,7 +72,7 @@ double run_sycl(
 
               // After computation, synchronize again, to ensure all
               // reads from the local memory tile are complete.
-              item.barrier();
+              group_barrier(item.get_group());
             }
 
             // Write the final result to global memory.

--- a/samples/Ch10_expressing_kernels/fig_10_3_optional_kernel_lambda_elements.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_3_optional_kernel_lambda_elements.cpp
@@ -29,7 +29,7 @@ int main() {
       accessor data_acc {data_buf, h};
 
       h.parallel_for(size,
-          [=](id<1> i) noexcept [[cl::reqd_work_group_size(8,1,1)]] -> void {
+          [=](id<1> i) noexcept [[sycl::reqd_work_group_size(8,1,1)]] -> void {
             data_acc[i] = data_acc[i] + 1;
           });
     });

--- a/samples/Ch14_common_parallel_patterns/fig_14_15_local_stencil.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_15_local_stencil.cpp
@@ -54,7 +54,7 @@ int main() {
                 tile[ti][tj] = input[gi][gj];
               }
             }
-            it.barrier(access::fence_space::local_space);
+            group_barrier(it.get_group());
 
             // Compute the stencil using values from local memory
             int gi = it.get_global_id(0) + 1;

--- a/samples/Ch14_common_parallel_patterns/fig_14_16_basic_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_16_basic_reduction.cpp
@@ -9,10 +9,6 @@
 using namespace sycl;
 
 int main() {
-
-  using memory_order = sycl::memory_order;
-  using memory_scope = sycl::memory_scope;
-
   constexpr size_t N = 16;
 
   queue Q;

--- a/samples/Ch14_common_parallel_patterns/fig_14_17_nd_range_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_17_nd_range_reduction.cpp
@@ -9,10 +9,6 @@
 using namespace sycl;
 
 int main() {
-
-  using memory_order = sycl::memory_order;
-  using memory_scope = sycl::memory_scope;
-
   constexpr size_t N = 16;
   constexpr size_t B = 4;
 

--- a/samples/Ch14_common_parallel_patterns/fig_14_18-20_inclusive_scan.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_18-20_inclusive_scan.cpp
@@ -40,15 +40,15 @@ int main() {
 
        // Copy input to local memory
        local[li] = input[i];
-       it.barrier();
+       group_barrier(it.get_group());
 
        // Perform inclusive scan in local memory
        for (int32_t d = 0; d <= log2((float)L) - 1; ++d) {
          uint32_t stride = (1 << d);
          int32_t update = (li >= stride) ? local[li - stride] : 0;
-         it.barrier();
+         group_barrier(it.get_group());
          local[li] += update;
-         it.barrier();
+         group_barrier(it.get_group());
        }
 
        // Write the result for each item to the output buffer
@@ -69,15 +69,15 @@ int main() {
 
        // Copy input to local memory
        local[li] = tmp[i];
-       it.barrier();
+       group_barrier(it.get_group());
 
        // Perform inclusive scan in local memory
        for (int32_t d = 0; d <= log2((float)G) - 1; ++d) {
          uint32_t stride = (1 << d);
          int32_t update = (li >= stride) ? local[li - stride] : 0;
-         it.barrier();
+         group_barrier(it.get_group());
          local[li] += update;
-         it.barrier();
+         group_barrier(it.get_group());
        }
 
        // Overwrite result from each work-item in the temporary buffer

--- a/samples/Ch14_common_parallel_patterns/fig_14_22_local_pack.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_22_local_pack.cpp
@@ -57,15 +57,15 @@ int main() {
 
            // Pack neighbors that require post-processing into a list
            uint32_t pack = (i != j) and (r <= CUTOFF);
-           uint32_t offset = exclusive_scan(sg, pack, plus<>());
+           uint32_t offset = exclusive_scan_over_group(sg, pack, plus<>());
            if (pack) {
              neighbors[i * MAX_K + k + offset] = j;
            }
 
            // Keep track of how many neighbors have been packed so far
-           k += reduce(sg, pack, plus<>());
+           k += reduce_over_group(sg, pack, plus<>());
          }
-         num_neighbors[i] = reduce(sg, k, maximum<>());
+         num_neighbors[i] = reduce_over_group(sg, k, maximum<>());
        })
       .wait();
 

--- a/samples/Ch14_common_parallel_patterns/fig_14_24_local_unpack.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_24_local_unpack.cpp
@@ -118,16 +118,16 @@ int main() {
         }
 
         // Keep iterating as long as one work-item has work to do
-        while (any_of(sg, i < Nx)) {
+        while (any_of_group(sg, i < Nx)) {
           uint32_t converged =
               next_iteration(params, i, j, count, cr, ci, zr, zi, mandelbrot);
-          if (any_of(sg, converged)) {
+          if (any_of_group(sg, converged)) {
 
             // Replace pixels that have converged using an unpack
             // Pixels that haven't converged are not replaced
-            uint32_t index = exclusive_scan(sg, converged, plus<>());
+            uint32_t index = exclusive_scan_over_group(sg, converged, plus<>());
             i = (converged) ? iq + index : i;
-            iq += reduce(sg, converged, plus<>());
+            iq += reduce_over_group(sg, converged, plus<>());
 
             // Reset the iterator variables for the new i
             if (converged) {

--- a/samples/Ch16_cpus/fig_16_12_forward_dep.cpp
+++ b/samples/Ch16_cpus/fig_16_12_forward_dep.cpp
@@ -32,10 +32,10 @@ int main()
       // load a[i*n+j+1:8] before updating a[i*n+j:8] to preserve
       // loop-carried forward dependency
       auto va = a[i*n + j + 1];
-      sg.barrier();
+      group_barrier(sg);
       a[i*n + j] = va + i + 2;
     }
-    sg.barrier();
+    group_barrier(sg);
 
   }).wait();
 

--- a/samples/Ch19_memory_model_and_atomics/fig_19_15_buffer_and_atomic_ref.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_15_buffer_and_atomic_ref.cpp
@@ -9,10 +9,6 @@
 using namespace sycl;
 
 int main() {
-
-  using memory_order = sycl::memory_order;
-  using memory_scope = sycl::memory_scope;
-
   queue Q;
 
   const size_t N = 32;

--- a/samples/Ch19_memory_model_and_atomics/fig_19_6_avoid_data_race_with_barrier.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_6_avoid_data_race_with_barrier.cpp
@@ -30,7 +30,7 @@ int main() {
        if (i == round) {
          data[j] += 1;
        }
-       it.barrier();
+       group_barrier(it.get_group());
      }
    }).wait();
 

--- a/samples/Ch19_memory_model_and_atomics/fig_19_7_avoid_data_race_with_atomics.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_7_avoid_data_race_with_atomics.cpp
@@ -9,10 +9,6 @@
 using namespace sycl;
 
 int main() {
-
-  using memory_order = sycl::memory_order;
-  using memory_scope = sycl::memory_scope;
-
   queue Q;
 
   const size_t N = 32;

--- a/samples/Epilogue_future_direction/fig_ep_7_hierarchical_reduction.cpp
+++ b/samples/Epilogue_future_direction/fig_ep_7_hierarchical_reduction.cpp
@@ -7,7 +7,6 @@
 #include <numeric>
 
 using namespace sycl;
-using namespace sycl::ONEAPI;
 
 int main() {
 


### PR DESCRIPTION
This PR makes the following changes:
 - Replaces operations on groups to use the SYCL 2020 variants.
 - Removes cast to internal pi_mem_advice in mem_advise.
 - Renames noinit property to no_init.
 - Replace cl::reqd_work_group_size with sycl::reqd_work_group_size
 - Removes redundant aliases.