### PR TITLE
Remove use of double from kernels

### DIFF
--- a/samples/Ch16_cpus/fig_16_6_stream_triad.cpp
+++ b/samples/Ch16_cpus/fig_16_6_stream_triad.cpp
@@ -14,9 +14,9 @@ constexpr int num_runs = 10;
 constexpr size_t scalar = 3;
 
 double triad(
-    const std::vector<double>& vecA,
-    const std::vector<double>& vecB,
-    std::vector<double>& vecC ) {
+    const std::vector<float>& vecA,
+    const std::vector<float>& vecB,
+    std::vector<float>& vecC ) {
 
   assert(vecA.size() == vecB.size() && vecB.size() == vecC.size());
   const size_t array_size = vecA.size();
@@ -25,9 +25,9 @@ double triad(
   queue Q{ property::queue::enable_profiling{} };
   std::cout << "Running on device: " << Q.get_device().get_info<info::device::name>() << "\n";
 
-  buffer<double> bufA(vecA);
-  buffer<double> bufB(vecB);
-  buffer<double> bufC(vecC);
+  buffer<float> bufA(vecA);
+  buffer<float> bufB(vecB);
+  buffer<float> bufC(vecC);
 
   for (int i = 0; i< num_runs; i++) {
     auto Q_event = Q.submit([&](handler& h) {
@@ -63,11 +63,11 @@ int main(int argc, char *argv[]) {
   }
 
   std::cout << "Running with stream size of " << array_size
-    << " elements (" << (array_size * sizeof(double))/(double)1024/1024 << "MB)\n";
+    << " elements (" << (array_size * sizeof(float))/(double)1024/1024 << "MB)\n";
 
-  std::vector<double> D(array_size, 1.0);
-  std::vector<double> E(array_size, 2.0);
-  std::vector<double> F(array_size, 0.0);
+  std::vector<float> D(array_size, 1.0);
+  std::vector<float> E(array_size, 2.0);
+  std::vector<float> F(array_size, 0.0);
 
   double min_time = triad(D, E, F);
 
@@ -80,7 +80,7 @@ int main(int argc, char *argv[]) {
   }
   std::cout << "Results are correct!\n\n";
 
-  size_t triad_bytes = 3 * sizeof(double) * array_size;
+  size_t triad_bytes = 3 * sizeof(float) * array_size;
   std::cout << "Triad Bytes: " << triad_bytes << "\n";
   std::cout << "Time in sec (fastest run): " << min_time * 1.0E-9 << "\n";
 

--- a/samples/Ch18_using_libs/fig_18_1_builtin.cpp
+++ b/samples/Ch18_using_libs/fig_18_1_builtin.cpp
@@ -10,8 +10,8 @@ using namespace sycl;
 
 int main() {
   constexpr int size = 9;
-  std::array<double, size> A;
-  std::array<double, size> B;
+  std::array<float, size> A;
+  std::array<float, size> B;
 
   bool pass = true;
 
@@ -21,8 +21,8 @@ int main() {
 
   range sz{size};
 
-  buffer<double> bufA(A);
-  buffer<double> bufB(B);
+  buffer<float> bufA(A);
+  buffer<float> bufB(B);
   buffer<bool>   bufP(&pass, 1);
 
   Q.submit([&](handler &h) {
@@ -42,7 +42,7 @@ int main() {
   host_accessor host_A(bufA);
   host_accessor host_P(bufP);
 
-  if (host_P[0] && host_A[4] == std::log(4.00)) {
+  if (host_P[0] && host_A[4] == std::log(4.00f)) {
     std::cout << "Passed\n";
   } else {
     std::cout << "Failed\n";


### PR DESCRIPTION
Using 64-bit floating points in SYCL kernels require the devices to support `aspect::fp64`. To avoid failures on systems that do not support 64-bit floating points, these changes replace all uses of double in kernels with float.