### PR TITLE
Replace placeholder accessor with host accessor

### DIFF
--- a/samples/Ch18_using_libs/fig_18_13_binary_search.cpp
+++ b/samples/Ch18_using_libs/fig_18_13_binary_search.cpp
@@ -24,8 +24,8 @@ int main()
     buffer<uint64_t, 1> vB{ range<1>(5) };
     buffer<uint64_t, 1> rB{ range<1>(5) };
     {
-      accessor k{kB};
-      accessor v{vB};
+      host_accessor k{kB};
+      host_accessor v{vB};
 
       // Initialize data, sorted
       k[0] = 0; k[1] = 5; k[2] = 6; k[3] = 6; k[4] = 7;


### PR DESCRIPTION
These changes replace the placeholder accessors in fig_18_13 with host_accessor to avoid invalid memory accesses.