### PR TITLE
Fix missed host accessor in fig_18_13

### DIFF
--- a/samples/Ch18_using_libs/fig_18_13_binary_search.cpp
+++ b/samples/Ch18_using_libs/fig_18_13_binary_search.cpp
@@ -48,7 +48,7 @@ int main()
     oneapi::dpl::binary_search(policy, k_beg, k_end, v_beg, v_end, r_beg);
 
     // check data
-    accessor r{rB};
+    host_accessor r{rB};
     if ((r[0] == false) && (r[1] == true) && (r[2] == false) && (r[3] == true) && (r[4] == true)) {
        std::cout << "Passed. \nRun on "
             << policy.queue().get_device().get_info<info::device::name>() << "\n";


### PR DESCRIPTION
Changes in https://github.com/Apress/data-parallel-CPP/pull/36 replaced most placeholder accessors in fig_18_13 but missed one. This commit fixes the missed accessor.