### PR TITLE
Disable fast-math for fig_14_13 to avoid precision errors (main)

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -9,7 +9,7 @@ function(add_book_sample)
 
     set(options TEST)
     set(one_value_args TARGET)
-    set(multi_value_args SOURCES LIBS)
+    set(multi_value_args SOURCES LIBS ADDITIONAL_COMPILE_OPTIONS)
     cmake_parse_arguments(BOOK_SAMPLE
         "${options}" "${one_value_args}" "${multi_value_args}"
         ${ARGN}
@@ -17,7 +17,7 @@ function(add_book_sample)
 
     add_executable(${BOOK_SAMPLE_TARGET} ${BOOK_SAMPLE_SOURCES})
 
-    target_compile_options(${BOOK_SAMPLE_TARGET} PRIVATE -fsycl -fsycl-unnamed-lambda -ferror-limit=1 -Wall -Wpedantic)
+    target_compile_options(${BOOK_SAMPLE_TARGET} PRIVATE -fsycl -fsycl-unnamed-lambda -ferror-limit=1 -Wall -Wpedantic ${BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS})
     # Passing -fsycl via target_link_libraries for older versions of CMake:
     #target_link_options(${BOOK_SAMPLE_TARGET} PRIVATE -fsycl )
     target_link_libraries(${BOOK_SAMPLE_TARGET} PRIVATE sycl -fsycl )

--- a/samples/Ch14_common_parallel_patterns/CMakeLists.txt
+++ b/samples/Ch14_common_parallel_patterns/CMakeLists.txt
@@ -15,7 +15,8 @@ add_book_sample(
 add_book_sample(
     TEST
     TARGET fig_14_13_map
-    SOURCES fig_14_13_map.cpp)
+    SOURCES fig_14_13_map.cpp
+    ADDITIONAL_COMPILE_OPTIONS -fno-fast-math)
 
 add_book_sample(
     TEST


### PR DESCRIPTION
DPC++ has fast-math enabled by default which means precision on floating point operations may reduce at the benefit of performance. However, for fig_14_13 this may cause the result check to fail. This commit disables fast-math for fig_14_13.

This is a cherry-pick of https://github.com/Apress/data-parallel-CPP/pull/38