### PR TITLE
Update samples to use most recent SYCL 2020 features from DPC++

### DIFF
--- a/samples/Ch01_intro/fig_1_1_hello.cpp
+++ b/samples/Ch01_intro/fig_1_1_hello.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 

--- a/samples/Ch01_intro/fig_1_3_race.cpp
+++ b/samples/Ch01_intro/fig_1_3_race.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 

--- a/samples/Ch02_where_code_runs/fig_2_10_cpu_selector.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_10_cpu_selector.cpp
@@ -2,13 +2,13 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 
 int main() {
   // Create queue to use the CPU device explicitly
-  queue Q{ cpu_selector{} };
+  queue Q{ cpu_selector_v };
 
   std::cout << "Selected device: " <<
     Q.get_device().get_info<info::device::name>() << "\n";

--- a/samples/Ch02_where_code_runs/fig_2_12_multiple_selectors.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_12_multiple_selectors.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_selector
 #include <iostream>
 #include <string>
@@ -16,10 +16,10 @@ void output_dev_info( const device& dev, const std::string& selector_name) {
 }
 
 int main() {
-  output_dev_info( device{ default_selector{}}, "default_selector" );
-  output_dev_info( device{ cpu_selector{}}, "cpu_selector" );
-  output_dev_info( device{ gpu_selector{}}, "gpu_selector" );
-  output_dev_info( device{ accelerator_selector{}}, "accelerator_selector" );
+  output_dev_info( device{ default_selector_v}, "default_selector" );
+  output_dev_info( device{ cpu_selector_v}, "cpu_selector" );
+  output_dev_info( device{ gpu_selector_v}, "gpu_selector" );
+  output_dev_info( device{ accelerator_selector_v}, "accelerator_selector" );
   output_dev_info( device{ ext::intel::fpga_selector{}}, "fpga_selector" );
 
   return 0;

--- a/samples/Ch02_where_code_runs/fig_2_13_gpu_plus_fpga.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_13_gpu_plus_fpga.cpp
@@ -2,13 +2,13 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_selector
 #include <iostream>
 using namespace sycl;
 
 int main() {
-  queue my_gpu_queue( gpu_selector{} );
+  queue my_gpu_queue( gpu_selector_v );
   queue my_fpga_queue( ext::intel::fpga_selector{} );
 
   std::cout << "Selected device 1: " <<

--- a/samples/Ch02_where_code_runs/fig_2_15_custom_selector.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_15_custom_selector.cpp
@@ -2,31 +2,25 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 
 // START CODE SNIP
 
-class my_selector : public device_selector {
-  public:
-    int operator()(const device &dev) const override {
-      if (
-          dev.get_info<info::device::name>().find("Arria")
-            != std::string::npos &&
-          dev.get_info<info::device::vendor>().find("Intel")
-            != std::string::npos) {
-        return 1;
-      }
-      return -1;
-    }
-};
+int my_selector(const device &dev) {
+  if (dev.get_info<info::device::name>().find("Arria") != std::string::npos &&
+      dev.get_info<info::device::vendor>().find("Intel") != std::string::npos) {
+    return 1;
+  }
+  return -1;
+}
 
 // END CODE SNIP
 
 
 int main() {
-  queue Q( my_selector{} );
+  queue Q( my_selector );
 
   std::cout << "Selected device is: " <<
     Q.get_device().get_info<info::device::name>() << "\n";

--- a/samples/Ch02_where_code_runs/fig_2_18_simple_device_code.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_18_simple_device_code.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch02_where_code_runs/fig_2_22_simple_device_code_2.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_22_simple_device_code_2.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch02_where_code_runs/fig_2_23_fallback.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_23_fallback.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -13,8 +13,8 @@ int main() {
   constexpr int local_size = 16;
   buffer<int,2> B{ range{ global_size, global_size }};
 
-  queue gpu_Q{ gpu_selector{} };
-  queue host_Q{ host_selector{} };
+  queue gpu_Q{ gpu_selector_v };
+  queue cpu_Q{ cpu_selector_v };
 
   nd_range NDR {
     range{ global_size, global_size },
@@ -27,7 +27,7 @@ int main() {
           auto ind = id.get_global_id();
           acc[ind] = ind[0] + ind[1];
           });
-      }, host_Q); /** <<== Fallback Queue Specified **/
+      }, cpu_Q); /** <<== Fallback Queue Specified **/
 
   host_accessor acc{B};
   for(int i=0; i < global_size; i++){

--- a/samples/Ch02_where_code_runs/fig_2_2_simple_program.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_2_simple_program.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch02_where_code_runs/fig_2_7_implicit_default_selector.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_7_implicit_default_selector.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 

--- a/samples/Ch02_where_code_runs/fig_2_9_host_selector.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_9_host_selector.cpp
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: MIT
 
 // TODO: Following example is already CPU selector.  Decide what to do with this one
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 
 int main() {
   // Create queue to use the host device explicitly
-  queue Q{ cpu_selector{} };
+  queue Q{ cpu_selector_v };
 
   std::cout << "Selected device: " <<
     Q.get_device().get_info<info::device::name>() << "\n";

--- a/samples/Ch03_data_management/fig_3_10_in_order.cpp
+++ b/samples/Ch03_data_management/fig_3_10_in_order.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 4;
 

--- a/samples/Ch03_data_management/fig_3_11_depends_on.cpp
+++ b/samples/Ch03_data_management/fig_3_11_depends_on.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 4;
 

--- a/samples/Ch03_data_management/fig_3_13_read_after_write.cpp
+++ b/samples/Ch03_data_management/fig_3_13_read_after_write.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 using namespace sycl;
 constexpr int N = 42;

--- a/samples/Ch03_data_management/fig_3_15_write_after_read_and_write_after_write.cpp
+++ b/samples/Ch03_data_management/fig_3_15_write_after_read_and_write_after_write.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 using namespace sycl;
 constexpr int N = 42;

--- a/samples/Ch03_data_management/fig_3_4_usm_explicit_data_movement.cpp
+++ b/samples/Ch03_data_management/fig_3_4_usm_explicit_data_movement.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include<array>
 using namespace sycl;
 constexpr int N = 42;

--- a/samples/Ch03_data_management/fig_3_5_usm_implicit_data_movement.cpp
+++ b/samples/Ch03_data_management/fig_3_5_usm_implicit_data_movement.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch03_data_management/fig_3_6_buffers_and_accessors.cpp
+++ b/samples/Ch03_data_management/fig_3_6_buffers_and_accessors.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 using namespace sycl;
 constexpr int N = 42;

--- a/samples/Ch04_expressing_parallelism/fig_4_13_nd_range_matrix_multiply.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_13_nd_range_matrix_multiply.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 #include <random>

--- a/samples/Ch04_expressing_parallelism/fig_4_20_hierarchical_matrix_multiply.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_20_hierarchical_matrix_multiply.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 #include <random>

--- a/samples/Ch04_expressing_parallelism/fig_4_22_hierarchical_logical_matrix_multiply.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_22_hierarchical_logical_matrix_multiply.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 #include <random>

--- a/samples/Ch04_expressing_parallelism/fig_4_5_vector_add.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_5_vector_add.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch04_expressing_parallelism/fig_4_6_matrix_add.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_6_matrix_add.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch04_expressing_parallelism/fig_4_7_basic_matrix_multiply.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_7_basic_matrix_multiply.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 #include <random>

--- a/samples/Ch05_error_handling/fig_5_1_async_task_graph.cpp
+++ b/samples/Ch05_error_handling/fig_5_1_async_task_graph.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 

--- a/samples/Ch05_error_handling/fig_5_2_sync_error.cpp
+++ b/samples/Ch05_error_handling/fig_5_2_sync_error.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 int main() {

--- a/samples/Ch05_error_handling/fig_5_3_async_error.cpp
+++ b/samples/Ch05_error_handling/fig_5_3_async_error.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 // Our simple asynchronous handler function
@@ -22,8 +22,8 @@ void say_device(const queue& Q) {
 }
 
 int main() { 
-  queue Q1{ gpu_selector{}, handle_async_error };
-  queue Q2{ cpu_selector{}, handle_async_error };
+  queue Q1{ gpu_selector_v, handle_async_error };
+  queue Q2{ cpu_selector_v, handle_async_error };
   say_device(Q1);
   say_device(Q2);
 

--- a/samples/Ch05_error_handling/fig_5_6_catch_snip.cpp
+++ b/samples/Ch05_error_handling/fig_5_6_catch_snip.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 int main() { 

--- a/samples/Ch05_error_handling/fig_5_7_catch.cpp
+++ b/samples/Ch05_error_handling/fig_5_7_catch.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 int main() { 

--- a/samples/Ch05_error_handling/fig_5_8_lambda_handler.cpp
+++ b/samples/Ch05_error_handling/fig_5_8_lambda_handler.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 // BEGIN CODE SNIP
@@ -26,8 +26,8 @@ void say_device(const queue& Q) {
 }
 
 int main() { 
-  queue Q1{ gpu_selector{}, handle_async_error };
-  queue Q2{ cpu_selector{}, handle_async_error };
+  queue Q1{ gpu_selector_v, handle_async_error };
+  queue Q2{ cpu_selector_v, handle_async_error };
   say_device(Q1);
   say_device(Q2);
 

--- a/samples/Ch05_error_handling/fig_5_9_default_handler_proxy.cpp
+++ b/samples/Ch05_error_handling/fig_5_9_default_handler_proxy.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 // BEGIN CODE SNIP
@@ -29,8 +29,8 @@ void say_device(const queue& Q) {
 }
 
 int main() { 
-  queue Q1{ gpu_selector{}, handle_async_error };
-  queue Q2{ cpu_selector{}, handle_async_error };
+  queue Q1{ gpu_selector_v, handle_async_error };
+  queue Q2{ cpu_selector_v, handle_async_error };
   say_device(Q1);
   say_device(Q2);
 

--- a/samples/Ch06_unified_shared_memory/fig_6_5_allocation_styles.cpp
+++ b/samples/Ch06_unified_shared_memory/fig_6_5_allocation_styles.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch06_unified_shared_memory/fig_6_6_usm_explicit_data_movement.cpp
+++ b/samples/Ch06_unified_shared_memory/fig_6_6_usm_explicit_data_movement.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 using namespace sycl;
 constexpr int N = 42;

--- a/samples/Ch06_unified_shared_memory/fig_6_7_usm_implicit_data_movement.cpp
+++ b/samples/Ch06_unified_shared_memory/fig_6_7_usm_implicit_data_movement.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch06_unified_shared_memory/fig_6_8_prefetch_memadvise.cpp
+++ b/samples/Ch06_unified_shared_memory/fig_6_8_prefetch_memadvise.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 // Appropriate values depend on your HW

--- a/samples/Ch06_unified_shared_memory/fig_6_9_queries.cpp
+++ b/samples/Ch06_unified_shared_memory/fig_6_9_queries.cpp
@@ -2,9 +2,9 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
-using dinfo = info::device;
+namespace dinfo = info::device;
 constexpr int N = 42;
 
 template <typename T> void foo(T data, id<1> i) { data[i] = N; }

--- a/samples/Ch07_buffers/fig_7_10_accessors.cpp
+++ b/samples/Ch07_buffers/fig_7_10_accessors.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <cassert>
 using namespace sycl;
 constexpr int N = 42;

--- a/samples/Ch07_buffers/fig_7_2_3_4_creating_buffers.cpp
+++ b/samples/Ch07_buffers/fig_7_2_3_4_creating_buffers.cpp
@@ -2,12 +2,12 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 int main() {
   // Create a buffer of 2x5 ints using the default allocator
-  buffer<int, 2, buffer_allocator> b1{range<2>{2, 5}};
+  buffer<int, 2, buffer_allocator<int>> b1{range<2>{2, 5}};
 
   // Create a buffer of 2x5 ints using the default allocator and CTAD for range
   buffer<int, 2> b2{range{2, 5}};

--- a/samples/Ch07_buffers/fig_7_5_buffer_properties.cpp
+++ b/samples/Ch07_buffers/fig_7_5_buffer_properties.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <mutex>
 using namespace sycl;
 

--- a/samples/Ch07_buffers/fig_7_8_accessors_simple.cpp
+++ b/samples/Ch07_buffers/fig_7_8_accessors_simple.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch08_graph_scheduling/fig_8_3_linear_dependence_in_order.cpp
+++ b/samples/Ch08_graph_scheduling/fig_8_3_linear_dependence_in_order.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch08_graph_scheduling/fig_8_4_linear_dependence_events.cpp
+++ b/samples/Ch08_graph_scheduling/fig_8_4_linear_dependence_events.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch08_graph_scheduling/fig_8_5_linear_dependence_buffers.cpp
+++ b/samples/Ch08_graph_scheduling/fig_8_5_linear_dependence_buffers.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch08_graph_scheduling/fig_8_6_y_in_order.cpp
+++ b/samples/Ch08_graph_scheduling/fig_8_6_y_in_order.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch08_graph_scheduling/fig_8_7_y_events.cpp
+++ b/samples/Ch08_graph_scheduling/fig_8_7_y_events.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch08_graph_scheduling/fig_8_8_y_buffers.cpp
+++ b/samples/Ch08_graph_scheduling/fig_8_8_y_buffers.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch09_work_item_communication/fig_9_10_hier_tiled_matmul.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_10_hier_tiled_matmul.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Ch09_work_item_communication/fig_9_11_sub_group_barrier.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_11_sub_group_barrier.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch09_work_item_communication/fig_9_13_matmul_broadcast.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_13_matmul_broadcast.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 
@@ -42,9 +42,7 @@ double run_sycl(
 
       // Local accessor, for one matrix tile:
       constexpr int tile_size = 16;
-      auto tileA =
-          accessor<T, 1, access::mode::read_write, access::target::local>(
-              tile_size, h);
+      auto tileA = local_accessor<T, 1>(tile_size, h);
 
 // BEGIN CODE SNIP
       h.parallel_for(

--- a/samples/Ch09_work_item_communication/fig_9_14_ndrange_sub_group_matmul.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_14_ndrange_sub_group_matmul.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Ch09_work_item_communication/fig_9_4_naive_matmul.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_4_naive_matmul.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Ch09_work_item_communication/fig_9_7_local_accessors.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_7_local_accessors.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -17,7 +17,7 @@ int main() {
   {
     buffer dataBuf{data};
 
-    queue Q{host_selector()};
+    queue Q{ default_selector_v };
     std::cout << "Running on device: "
               << Q.get_device().get_info<info::device::name>() << "\n";
 
@@ -27,14 +27,10 @@ int main() {
       accessor dataAcc {dataBuf, h};
 
       // This is a 1D local accessor consisting of 16 ints:
-      auto localIntAcc =
-          accessor<int, 1, access::mode::read_write, access::target::local>(
-              16, h);
+      auto localIntAcc = local_accessor<int, 1>(16, h);
 
       // This is a 2D local accessor consisting of 4 x 4 floats:
-      auto localFloatAcc =
-          accessor<float, 2, access::mode::read_write, access::target::local>(
-              {4, 4}, h);
+      auto localFloatAcc = local_accessor<float, 2>({4, 4}, h);
 
       h.parallel_for(nd_range<1>{{size}, {16}}, [=](nd_item<1> item) {
         auto index = item.get_global_id();

--- a/samples/Ch09_work_item_communication/fig_9_8_ndrange_tiled_matmul.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_8_ndrange_tiled_matmul.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 
@@ -43,9 +43,7 @@ double run_sycl(
 
       // Local accessor, for one matrix tile:
       constexpr int tile_size = 16;
-      auto tileA =
-          accessor<T, 1, access::mode::read_write, access::target::local>(
-              tile_size, h);
+      auto tileA = local_accessor<T, 1>(tile_size, h);
 
       h.parallel_for(
           nd_range<2>{{M, N}, {1, tile_size}}, [=](nd_item<2> item) {

--- a/samples/Ch09_work_item_communication/fig_9_9_local_hier.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_9_local_hier.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch09_work_item_communication/matmul_harness.cpp
+++ b/samples/Ch09_work_item_communication/matmul_harness.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch10_expressing_kernels/fig_10_2_kernel_lambda.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_2_kernel_lambda.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -20,7 +20,7 @@ int main() {
   {
     buffer data_buf{data};
 
-    queue Q{ host_selector{} };
+    queue Q{ default_selector_v };
     std::cout << "Running on device: "
               << Q.get_device().get_info<info::device::name>() << "\n";
 

--- a/samples/Ch10_expressing_kernels/fig_10_3_optional_kernel_lambda_elements.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_3_optional_kernel_lambda_elements.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -20,7 +20,7 @@ int main() {
   {
     buffer data_buf{data};
 
-    queue Q{ host_selector{} };
+    queue Q{ default_selector_v };
     std::cout << "Running on device: "
               << Q.get_device().get_info<info::device::name>() << "\n";
 

--- a/samples/Ch10_expressing_kernels/fig_10_4_named_kernel_lambda.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_4_named_kernel_lambda.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -18,7 +18,7 @@ int main() {
   {
     buffer data_buf{data};
 
-    queue Q{ host_selector{} };
+    queue Q{ default_selector_v };
     std::cout << "Running on device: "
               << Q.get_device().get_info<info::device::name>() << "\n";
 

--- a/samples/Ch10_expressing_kernels/fig_10_5_unnamed_kernel_lambda.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_5_unnamed_kernel_lambda.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -18,7 +18,7 @@ int main() {
   {
     buffer data_buf{data};
 
-    queue Q{ host_selector{} };
+    queue Q{ default_selector_v };
     std::cout << "Running on device: "
               << Q.get_device().get_info<info::device::name>() << "\n";
 

--- a/samples/Ch10_expressing_kernels/fig_10_6_kernel_functor.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_6_kernel_functor.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -30,7 +30,7 @@ int main() {
   {
     buffer data_buf{data};
 
-    queue Q{ host_selector{} };
+    queue Q{ default_selector_v };
     std::cout << "Running on device: "
               << Q.get_device().get_info<info::device::name>() << "\n";
 

--- a/samples/Ch10_expressing_kernels/fig_10_8_opencl_object_interop.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_8_opencl_object_interop.cpp
@@ -2,9 +2,9 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <CL/cl.h>
-#include <CL/sycl/backend/opencl.hpp>
+#include <sycl/backend/opencl.hpp>
 #include <iostream>
 using namespace sycl;
 
@@ -22,7 +22,7 @@ int main() {
 // BEGIN CODE SNIP
     // Note: This must select a device that supports interop with OpenCL kernel
     // objects!
-    queue Q{ cpu_selector{} };
+    queue Q{ cpu_selector_v };
     context sc = Q.get_context();
 
     const char* kernelSource =

--- a/samples/Ch10_expressing_kernels/fig_10_9_kernel_lambda_build_options.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_9_kernel_lambda_build_options.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -20,7 +20,7 @@ int main() {
   {
     buffer data_buf{data};
 
-    queue Q{ cpu_selector{} };
+    queue Q{ cpu_selector_v };
     std::cout << "Running on device: "
               << Q.get_device().get_info<info::device::name>() << "\n";
 

--- a/samples/Ch11_vectors/fig_11_6_load_store.cpp
+++ b/samples/Ch11_vectors/fig_11_6_load_store.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 #include<array>
-#include<CL/sycl.hpp>
+#include<sycl/sycl.hpp>
 using namespace sycl;
 
 int main() {

--- a/samples/Ch11_vectors/fig_11_7_swizzle_vec.cpp
+++ b/samples/Ch11_vectors/fig_11_7_swizzle_vec.cpp
@@ -4,7 +4,7 @@
 
 #define SYCL_SIMPLE_SWIZZLES
 #include <array>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 int main() {

--- a/samples/Ch11_vectors/fig_11_8_vector_exec.cpp
+++ b/samples/Ch11_vectors/fig_11_8_vector_exec.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 #include<array>
-#include<CL/sycl.hpp>
+#include<sycl/sycl.hpp>
 using namespace sycl;
 
 int main() {

--- a/samples/Ch12_device_information/fig_12_1_assigned_device.cpp
+++ b/samples/Ch12_device_information/fig_12_1_assigned_device.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 

--- a/samples/Ch12_device_information/fig_12_2_try_catch.cpp
+++ b/samples/Ch12_device_information/fig_12_2_try_catch.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 
@@ -12,13 +12,13 @@ int main() {
   auto GPU_is_available = false;
 
   try {
-    device testForGPU((gpu_selector()));
+    device testForGPU(gpu_selector_v);
     GPU_is_available = true;
   } catch (exception const& ex) {
     std::cout << "Caught this SYCL exception: " << ex.what() << std::endl;
   }
 
-  auto Q = GPU_is_available ? queue(gpu_selector()) : queue(host_selector());
+  auto Q = GPU_is_available ? queue(gpu_selector_v) : queue(default_selector_v);
 
   std::cout << "After checking for a GPU, we are running on:\n "
     << Q.get_device().get_info<info::device::name>() << "\n";
@@ -29,7 +29,7 @@ int main() {
   // 
   // sample output using a system with an FPGA accelerator, but no GPU:
   // Caught this SYCL exception: No device of requested type available.
-  // ...(CL_DEVICE_NOT_FOUND)
+  // ...(PI_ERROR_DEVICE_NOT_FOUND)
   // After checking for a GPU, we are running on:
   //  SYCL host device.
   //

--- a/samples/Ch12_device_information/fig_12_3_device_selector.cpp
+++ b/samples/Ch12_device_information/fig_12_3_device_selector.cpp
@@ -2,38 +2,37 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 
-class my_selector : public device_selector {
-  public:
-    int operator()(const device &dev) const {
-      int score = -1;
+int my_selector(const device &dev) {
+  int score = -1;
 
-      // We prefer non-Martian GPUs, especially ACME GPUs
-      if (dev.is_gpu()) {
-        if (dev.get_info<info::device::vendor>().find("ACME")
-            != std::string::npos) score += 25;
+  // We prefer non-Martian GPUs, especially ACME GPUs
+  if (dev.is_gpu()) {
+    if (dev.get_info<info::device::vendor>().find("ACME") != std::string::npos)
+      score += 25;
 
-        if (dev.get_info<info::device::vendor>().find("Martian")
-            == std::string::npos) score += 800;
-      }
+    if (dev.get_info<info::device::vendor>().find("Martian") ==
+        std::string::npos)
+      score += 800;
+  }
 
-      // Give host device points so it is used if no GPU is available.
-      // Without these next two lines, systems with no GPU would select
-      // nothing, since we initialize the score to a negative number above.
-      if (dev.is_host()) score += 100;
-
-      return score;
-    }
-};
+  // If there is no GPU on the system all devices will be given a negative score
+  // and the selector will not select a device. This will cause an exception.
+  return score;
+}
 
 int main() {
-  auto Q = queue{ my_selector{} };
-
-  std::cout << "After checking for a GPU, we are running on:\n "
-    << Q.get_device().get_info<info::device::name>() << "\n";
+  try {
+    auto Q = queue{ my_selector };
+    std::cout << "After checking for a GPU, we are running on:\n "
+              << Q.get_device().get_info<info::device::name>() << "\n";
+  } catch (exception const& ex) {
+    std::cout << "Custom device selector did not select a device.\n";
+    std::cout << "Caught this SYCL exception: " << ex.what() << std::endl;
+  }
 
   // Sample output using a system with a GPU:
   // After checking for a GPU, we are running on:
@@ -41,7 +40,9 @@ int main() {
   // 
   // Sample output using a system with an FPGA accelerator, but no GPU:
   // After checking for a GPU, we are running on:
-  //  SYCL host device.
+  //  Custom device selector did not select a device.
+  //  Caught this SYCL exception: No device of requested type available.
+  //  ...(PI_ERROR_DEVICE_NOT_FOUND)
 
   return 0;
 }

--- a/samples/Ch12_device_information/fig_12_4_curious.cpp
+++ b/samples/Ch12_device_information/fig_12_4_curious.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 

--- a/samples/Ch12_device_information/fig_12_6_very_curious.cpp
+++ b/samples/Ch12_device_information/fig_12_6_very_curious.cpp
@@ -2,14 +2,14 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 
-template <auto query, typename T>
+template <typename queryT, typename T>
 void do_query( const T& obj_to_query, const std::string& name, int indent=4) {
   std::cout << std::string(indent, ' ') << name << " is '"
-    << obj_to_query.template get_info<query>() << "'\n";
+    << obj_to_query.template get_info<queryT>() << "'\n";
 }
 
 
@@ -25,7 +25,6 @@ int main() {
     // Loop through the devices available in this plaform
     for (auto &dev : this_platform.get_devices() ) {
       std::cout << "  Device: " << dev.get_info<info::device::name>() << "\n";
-      std::cout << "    is_host(): " << (dev.is_host() ? "Yes" : "No") << "\n";
       std::cout << "    is_cpu(): " << (dev.is_cpu() ? "Yes" : "No") << "\n";
       std::cout << "    is_gpu(): " << (dev.is_gpu() ? "Yes" : "No") << "\n";
       std::cout << "    is_accelerator(): "

--- a/samples/Ch12_device_information/fig_12_7_invocation_parameters.cpp
+++ b/samples/Ch12_device_information/fig_12_7_invocation_parameters.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 

--- a/samples/Ch13_practical_tips/fig_13_10_host_accessor_deadlock.cpp
+++ b/samples/Ch13_practical_tips/fig_13_10_host_accessor_deadlock.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch13_practical_tips/fig_13_4_stream.cpp
+++ b/samples/Ch13_practical_tips/fig_13_4_stream.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include<CL/sycl.hpp>
+#include<sycl/sycl.hpp>
 #include<iostream>
 using namespace sycl;
 

--- a/samples/Ch13_practical_tips/fig_13_6_common_buffer_pattern.cpp
+++ b/samples/Ch13_practical_tips/fig_13_6_common_buffer_pattern.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch13_practical_tips/fig_13_7_common_pattern_bug.cpp
+++ b/samples/Ch13_practical_tips/fig_13_7_common_pattern_bug.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch13_practical_tips/fig_13_8_host_accessor.cpp
+++ b/samples/Ch13_practical_tips/fig_13_8_host_accessor.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch13_practical_tips/fig_13_9_host_accessor_for_init.cpp
+++ b/samples/Ch13_practical_tips/fig_13_9_host_accessor_for_init.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch14_common_parallel_patterns/fig_14_11_user_defined_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_11_user_defined_reduction.cpp
@@ -9,7 +9,7 @@
 //   added sycl::ONEAPI:: to minimum.
 // -------------------------------------------------------
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <random>
 

--- a/samples/Ch14_common_parallel_patterns/fig_14_13_map.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_13_map.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>

--- a/samples/Ch14_common_parallel_patterns/fig_14_14_stencil.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_14_stencil.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>

--- a/samples/Ch14_common_parallel_patterns/fig_14_15_local_stencil.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_15_local_stencil.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
@@ -11,10 +11,6 @@
 #include <random>
 
 using namespace sycl;
-
-template <typename T, int dimensions>
-using local_accessor =
-    accessor<T, dimensions, access::mode::read_write, access::target::local>;
 
 int main() {
   queue Q;

--- a/samples/Ch14_common_parallel_patterns/fig_14_16_basic_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_16_basic_reduction.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <numeric>
 

--- a/samples/Ch14_common_parallel_patterns/fig_14_17_nd_range_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_17_nd_range_reduction.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <cstdio>
 #include <numeric>
 

--- a/samples/Ch14_common_parallel_patterns/fig_14_18-20_inclusive_scan.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_18-20_inclusive_scan.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
@@ -11,10 +11,6 @@
 #include <random>
 
 using namespace sycl;
-
-template <typename T, int dimensions>
-using local_accessor =
-    accessor<T, dimensions, access::mode::read_write, access::target::local>;
 
 int main() {
   queue q;

--- a/samples/Ch14_common_parallel_patterns/fig_14_22_local_pack.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_22_local_pack.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
@@ -11,10 +11,6 @@
 #include <random>
 
 using namespace sycl;
-
-template <typename T, int dimensions>
-using local_accessor =
-    accessor<T, dimensions, access::mode::read_write, access::target::local>;
 
 int main() {
   queue Q;

--- a/samples/Ch14_common_parallel_patterns/fig_14_24_local_unpack.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_24_local_unpack.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <complex>
 #include <cstdio>

--- a/samples/Ch14_common_parallel_patterns/fig_14_8_one_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_8_one_reduction.cpp
@@ -9,7 +9,7 @@
 //   added sycl::ONEAPI:: to plus
 // -------------------------------------------------------
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <numeric>
 

--- a/samples/Ch15_gpus/fig_15_10_divergent_control_flow.cpp
+++ b/samples/Ch15_gpus/fig_15_10_divergent_control_flow.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -17,7 +17,7 @@ int main() {
 
   buffer dataBuf{data};
 
-  queue Q{ host_selector{} };
+  queue Q{ default_selector_v };
   Q.submit([&](handler& h) {
       accessor dataAcc{ dataBuf, h };
 

--- a/samples/Ch15_gpus/fig_15_12_small_work_group_matrix_multiplication.cpp
+++ b/samples/Ch15_gpus/fig_15_12_small_work_group_matrix_multiplication.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Ch15_gpus/fig_15_18_columns_matrix_multiplication.cpp
+++ b/samples/Ch15_gpus/fig_15_18_columns_matrix_multiplication.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Ch15_gpus/fig_15_3_single_task_matrix_multiplication.cpp
+++ b/samples/Ch15_gpus/fig_15_3_single_task_matrix_multiplication.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Ch15_gpus/fig_15_5_somewhat_parallel_matrix_multiplication.cpp
+++ b/samples/Ch15_gpus/fig_15_5_somewhat_parallel_matrix_multiplication.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Ch15_gpus/fig_15_7_more_parallel_matrix_multiplication.cpp
+++ b/samples/Ch15_gpus/fig_15_7_more_parallel_matrix_multiplication.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Ch15_gpus/matrix_multiplication_harness.cpp
+++ b/samples/Ch15_gpus/matrix_multiplication_harness.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch16_cpus/fig_16_12_forward_dep.cpp
+++ b/samples/Ch16_cpus/fig_16_12_forward_dep.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 
 using namespace sycl;

--- a/samples/Ch16_cpus/fig_16_18_vector_swizzle.cpp
+++ b/samples/Ch16_cpus/fig_16_18_vector_swizzle.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 #define SYCL_SIMPLE_SWIZZLES
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 
 using namespace sycl;

--- a/samples/Ch16_cpus/fig_16_6_stream_triad.cpp
+++ b/samples/Ch16_cpus/fig_16_6_stream_triad.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <cassert>
 #include <cfloat>

--- a/samples/Ch17_fpgas/fig_17_11_fpga_emulator_selector.cpp
+++ b/samples/Ch17_fpgas/fig_17_11_fpga_emulator_selector.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_selector
 using namespace sycl;
 

--- a/samples/Ch17_fpgas/fig_17_17_ndrange_func.cpp
+++ b/samples/Ch17_fpgas/fig_17_17_ndrange_func.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_emulator_selector
 using namespace sycl;
 

--- a/samples/Ch17_fpgas/fig_17_18_loop_func.cpp
+++ b/samples/Ch17_fpgas/fig_17_18_loop_func.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_emulator_selector
 using namespace sycl;
 

--- a/samples/Ch17_fpgas/fig_17_20_loop_carried_deps.cpp
+++ b/samples/Ch17_fpgas/fig_17_20_loop_carried_deps.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_emulator_selector
 using namespace sycl;
 

--- a/samples/Ch17_fpgas/fig_17_22_loop_carried_state.cpp
+++ b/samples/Ch17_fpgas/fig_17_22_loop_carried_state.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_emulator_selector
 using namespace sycl;
 

--- a/samples/Ch17_fpgas/fig_17_31_inter_kernel_pipe.cpp
+++ b/samples/Ch17_fpgas/fig_17_31_inter_kernel_pipe.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_emulator_selector
 #include <array>
 using namespace sycl;

--- a/samples/Ch17_fpgas/fig_17_9_fpga_selector.cpp
+++ b/samples/Ch17_fpgas/fig_17_9_fpga_selector.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_selector
 using namespace sycl;
 

--- a/samples/Ch18_using_libs/fig_18_11_std_fill.cpp
+++ b/samples/Ch18_using_libs/fig_18_11_std_fill.cpp
@@ -10,7 +10,7 @@
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/iterator>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 int main(){
   sycl::queue Q;

--- a/samples/Ch18_using_libs/fig_18_13_binary_search.cpp
+++ b/samples/Ch18_using_libs/fig_18_13_binary_search.cpp
@@ -14,7 +14,7 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/iterator>
 #include <iostream>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 using namespace sycl;
 

--- a/samples/Ch18_using_libs/fig_18_15_pstl_usm.cpp
+++ b/samples/Ch18_using_libs/fig_18_15_pstl_usm.cpp
@@ -9,7 +9,7 @@
 
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 int main(){
   sycl::queue Q;

--- a/samples/Ch18_using_libs/fig_18_1_builtin.cpp
+++ b/samples/Ch18_using_libs/fig_18_1_builtin.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <cmath>
 #include <iostream>

--- a/samples/Ch18_using_libs/fig_18_7_swap.cpp
+++ b/samples/Ch18_using_libs/fig_18_7_swap.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 #include <utility>

--- a/samples/Ch19_memory_model_and_atomics/fig_19_15_buffer_and_atomic_ref.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_15_buffer_and_atomic_ref.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 

--- a/samples/Ch19_memory_model_and_atomics/fig_19_18_histogram.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_18_histogram.cpp
@@ -2,17 +2,13 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <cstdio>
 #include <numeric>
 #include <random>
 
 using namespace sycl;
-
-template <typename T, int dimensions>
-using local_accessor =
-    accessor<T, dimensions, access::mode::read_write, access::target::local>;
 
 std::tuple<size_t, size_t> distribute_range(group<1> g, size_t N) {
   size_t work_per_group = N / g.get_group_range(0);

--- a/samples/Ch19_memory_model_and_atomics/fig_19_19-20_device_latch.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_19-20_device_latch.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <cassert>
 #include <cstdio>
 

--- a/samples/Ch19_memory_model_and_atomics/fig_19_3_data_race.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_3_data_race.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 

--- a/samples/Ch19_memory_model_and_atomics/fig_19_6_avoid_data_race_with_barrier.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_6_avoid_data_race_with_barrier.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 

--- a/samples/Ch19_memory_model_and_atomics/fig_19_7_avoid_data_race_with_atomics.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_7_avoid_data_race_with_atomics.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 

--- a/samples/Epilogue_future_direction/fig_ep_1_mdspan.cpp
+++ b/samples/Epilogue_future_direction/fig_ep_1_mdspan.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <experimental/mdspan>
 
 using namespace sycl;

--- a/samples/Epilogue_future_direction/fig_ep_2-4_generic_space.cpp
+++ b/samples/Epilogue_future_direction/fig_ep_2-4_generic_space.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 using namespace sycl;
 

--- a/samples/Epilogue_future_direction/fig_ep_5_extension_mechanism.cpp
+++ b/samples/Epilogue_future_direction/fig_ep_5_extension_mechanism.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Epilogue_future_direction/fig_ep_6_device_constexpr.cpp
+++ b/samples/Epilogue_future_direction/fig_ep_6_device_constexpr.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 using namespace sycl;
 

--- a/samples/Epilogue_future_direction/fig_ep_7_hierarchical_reduction.cpp
+++ b/samples/Epilogue_future_direction/fig_ep_7_hierarchical_reduction.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <numeric>
 


### PR DESCRIPTION
This commit adjusts tests in accordance with recent SYCL 2020 feature support added to open-source DPC++. In summary, the changes are the following:
* Changes the included headers from CL/sycl.hpp to sycl/sycl.hpp.
* Remove the CL prefix from the OpenCL backend header path.
* Removed local_accessor aliases from the samples that previously defined them.
* Changed accessors with access::target::local to use local_accessor.
* Changed standard SYCL selectors to use the SYCL 2020 callable variants instead of the SYCL 1.2.1 callable classes.
* Remove uses of host device and checks related to it.
* Adjusted info descriptors to be types instead of enumerator values.