### PR TITLE
Remove old CMake workaround causing failure on Windows (#41)

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -18,9 +18,6 @@ function(add_book_sample)
     add_executable(${BOOK_SAMPLE_TARGET} ${BOOK_SAMPLE_SOURCES})
 
     target_compile_options(${BOOK_SAMPLE_TARGET} PRIVATE -fsycl -fsycl-unnamed-lambda -ferror-limit=1 -Wall -Wpedantic ${BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS})
-    # Passing -fsycl via target_link_libraries for older versions of CMake:
-    #target_link_options(${BOOK_SAMPLE_TARGET} PRIVATE -fsycl )
-    target_link_libraries(${BOOK_SAMPLE_TARGET} PRIVATE sycl -fsycl )
 
     target_link_libraries(${BOOK_SAMPLE_TARGET} PRIVATE ${BOOK_SAMPLE_LIBS})
 


### PR DESCRIPTION
The CMake for the samples use a work-around for linking the SYCL libraries, however this causes failures on Windows due to explicit linking rather than letting the DPC++ driver handle it correctly when passed the -fsycl flag. This commit removes the workaround as it is believed to no longer be needed.