### PR TITLE
Collapse the sycl2020_updates branch to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Parallel C++ Book Source Samples
 
-THIS BRANCH (sycl2020_updates) is a WORK IN PROGRESS to align with SYCL 2020 (compilers are in various stages of supporting) for the Second Edition of the book which we plan to publish by the end of 2022.
+THIS BRANCH (sycl2020_updates) is a WORK IN PROGRESS to align with SYCL 2020 (compilers for SYCL, including DPC++, are in various stages of supporting) for the Second Edition of the book which we plan to publish by the end of 2022.
 
 This repository accompanies [*Data Parallel C++: Mastering DPC++ for Programming of Heterogeneous Systems using C++ and SYCL*](https://www.apress.com/9781484255735) by James Reinders, Ben Ashbaugh, James Brodman, Michael Kinsner, John Pennycook, Xinmin Tian (Apress, 2020).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Data Parallel C++ Book Source Samples
 
+THIS BRANCH (sycl2020_updates) is a WORK IN PROGRESS to align with SYCL 2020 (compilers are in various stages of supporting) for the Second Edition of the book which we plan to publish by the end of 2022.
+
 This repository accompanies [*Data Parallel C++: Mastering DPC++ for Programming of Heterogeneous Systems using C++ and SYCL*](https://www.apress.com/9781484255735) by James Reinders, Ben Ashbaugh, James Brodman, Michael Kinsner, John Pennycook, Xinmin Tian (Apress, 2020).
 
 [comment]: #cover

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # Data Parallel C++ Book Source Samples
 
-THIS BRANCH (sycl2020_updates) is a WORK IN PROGRESS to align with SYCL 2020 (compilers for SYCL, including DPC++, are in various stages of supporting) for the Second Edition of the book which we plan to publish by the end of 2022.
-
 This repository accompanies [*Data Parallel C++: Mastering DPC++ for Programming of Heterogeneous Systems using C++ and SYCL*](https://www.apress.com/9781484255735) by James Reinders, Ben Ashbaugh, James Brodman, Michael Kinsner, John Pennycook, Xinmin Tian (Apress, 2020).
 
 [comment]: #cover
 ![Cover image](9781484255735.jpg)
+
+## Purpose of this branch (main)
+
+This branch (main) contains source code derived from what was published with the First Edition of the DPC++ book, but modified to be compatible with the SYCL 2020 specification which was released by The Khronos Group after book publication.  The original book source was primarily based on the older SYCL 1.2.1 specification, and many enhancements and changes were added in the later SYCL 2020 specification.  More importantly, most current toolchains which support SYCL are based on SYCL 2020, so this main branch is intended to be compatible with recent compiler and toolchain releases.
+
+The Second Edition of the DPC++ book, likely to release in 2023, will be based on the updated code examples in this main branch.
+
+## Overview
 
 Many of the samples in the book are snips from the more complete files in this repository.  The full files contain supporting code, such as header inclusions, which are not shown in every listing within the book.  The complete listings are intended to compile and be modifiable for experimentation.
 

--- a/book_errata.txt
+++ b/book_errata.txt
@@ -2,6 +2,16 @@ The following are known errors in the book Data Parallel C++: Mastering DPC++ fo
 Programming of Heterogeneous Systems using C++ and SYCL by James Reinders, Ben Ashbaugh,
 James Brodman, Michael Kinsner, John Pennycook, Xinmin Tian (Apress, 2020).
 
+p.35 - Fig 2-7 - Output of code:
+       Device: SYCL host device
+       should read
+       Selected device: SYCL host device
+
+p.37 - Fig 2-9 - Output of code:
+       Device: SYCL host device
+       should read
+       Selected device: SYCL host device
+
 p.106 - Fig 4-11 - Comment in code:
 // Return the offset of this item (if with_offset == true)
 should read:

--- a/samples/Ch01_intro/fig_1_1_hello.cpp
+++ b/samples/Ch01_intro/fig_1_1_hello.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 

--- a/samples/Ch01_intro/fig_1_3_race.cpp
+++ b/samples/Ch01_intro/fig_1_3_race.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 

--- a/samples/Ch02_where_code_runs/fig_2_10_cpu_selector.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_10_cpu_selector.cpp
@@ -2,13 +2,13 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 
 int main() {
   // Create queue to use the CPU device explicitly
-  queue Q{ cpu_selector{} };
+  queue Q{ cpu_selector_v };
 
   std::cout << "Selected device: " <<
     Q.get_device().get_info<info::device::name>() << "\n";

--- a/samples/Ch02_where_code_runs/fig_2_12_multiple_selectors.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_12_multiple_selectors.cpp
@@ -17,7 +17,6 @@ void output_dev_info( const device& dev, const std::string& selector_name) {
 
 int main() {
   output_dev_info( device{ default_selector{}}, "default_selector" );
-  output_dev_info( device{ host_selector{}}, "host_selector" );
   output_dev_info( device{ cpu_selector{}}, "cpu_selector" );
   output_dev_info( device{ gpu_selector{}}, "gpu_selector" );
   output_dev_info( device{ accelerator_selector{}}, "accelerator_selector" );

--- a/samples/Ch02_where_code_runs/fig_2_12_multiple_selectors.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_12_multiple_selectors.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_selector
 #include <iostream>
 #include <string>
@@ -16,10 +16,10 @@ void output_dev_info( const device& dev, const std::string& selector_name) {
 }
 
 int main() {
-  output_dev_info( device{ default_selector{}}, "default_selector" );
-  output_dev_info( device{ cpu_selector{}}, "cpu_selector" );
-  output_dev_info( device{ gpu_selector{}}, "gpu_selector" );
-  output_dev_info( device{ accelerator_selector{}}, "accelerator_selector" );
+  output_dev_info( device{ default_selector_v}, "default_selector" );
+  output_dev_info( device{ cpu_selector_v}, "cpu_selector" );
+  output_dev_info( device{ gpu_selector_v}, "gpu_selector" );
+  output_dev_info( device{ accelerator_selector_v}, "accelerator_selector" );
   output_dev_info( device{ ext::intel::fpga_selector{}}, "fpga_selector" );
 
   return 0;

--- a/samples/Ch02_where_code_runs/fig_2_13_gpu_plus_fpga.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_13_gpu_plus_fpga.cpp
@@ -2,13 +2,13 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_selector
 #include <iostream>
 using namespace sycl;
 
 int main() {
-  queue my_gpu_queue( gpu_selector{} );
+  queue my_gpu_queue( gpu_selector_v );
   queue my_fpga_queue( ext::intel::fpga_selector{} );
 
   std::cout << "Selected device 1: " <<

--- a/samples/Ch02_where_code_runs/fig_2_15_custom_selector.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_15_custom_selector.cpp
@@ -2,31 +2,25 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 
 // START CODE SNIP
 
-class my_selector : public device_selector {
-  public:
-    int operator()(const device &dev) const override {
-      if (
-          dev.get_info<info::device::name>().find("Arria")
-            != std::string::npos &&
-          dev.get_info<info::device::vendor>().find("Intel")
-            != std::string::npos) {
-        return 1;
-      }
-      return -1;
-    }
-};
+int my_selector(const device &dev) {
+  if (dev.get_info<info::device::name>().find("Arria") != std::string::npos &&
+      dev.get_info<info::device::vendor>().find("Intel") != std::string::npos) {
+    return 1;
+  }
+  return -1;
+}
 
 // END CODE SNIP
 
 
 int main() {
-  queue Q( my_selector{} );
+  queue Q( my_selector );
 
   std::cout << "Selected device is: " <<
     Q.get_device().get_info<info::device::name>() << "\n";

--- a/samples/Ch02_where_code_runs/fig_2_18_simple_device_code.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_18_simple_device_code.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch02_where_code_runs/fig_2_22_simple_device_code_2.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_22_simple_device_code_2.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch02_where_code_runs/fig_2_23_fallback.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_23_fallback.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -13,8 +13,8 @@ int main() {
   constexpr int local_size = 16;
   buffer<int,2> B{ range{ global_size, global_size }};
 
-  queue gpu_Q{ gpu_selector{} };
-  queue host_Q{ host_selector{} };
+  queue gpu_Q{ gpu_selector_v };
+  queue cpu_Q{ cpu_selector_v };
 
   nd_range NDR {
     range{ global_size, global_size },
@@ -27,7 +27,7 @@ int main() {
           auto ind = id.get_global_id();
           acc[ind] = ind[0] + ind[1];
           });
-      }, host_Q); /** <<== Fallback Queue Specified **/
+      }, cpu_Q); /** <<== Fallback Queue Specified **/
 
   host_accessor acc{B};
   for(int i=0; i < global_size; i++){

--- a/samples/Ch02_where_code_runs/fig_2_2_simple_program.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_2_simple_program.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch02_where_code_runs/fig_2_7_implicit_default_selector.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_7_implicit_default_selector.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 

--- a/samples/Ch02_where_code_runs/fig_2_9_host_selector.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_9_host_selector.cpp
@@ -2,13 +2,14 @@
 
 // SPDX-License-Identifier: MIT
 
+// TODO: Following example is already CPU selector.  Decide what to do with this one
 #include <CL/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 
 int main() {
   // Create queue to use the host device explicitly
-  queue Q{ host_selector{} };
+  queue Q{ cpu_selector{} };
 
   std::cout << "Selected device: " <<
     Q.get_device().get_info<info::device::name>() << "\n";

--- a/samples/Ch02_where_code_runs/fig_2_9_host_selector.cpp
+++ b/samples/Ch02_where_code_runs/fig_2_9_host_selector.cpp
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: MIT
 
 // TODO: Following example is already CPU selector.  Decide what to do with this one
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 
 int main() {
   // Create queue to use the host device explicitly
-  queue Q{ cpu_selector{} };
+  queue Q{ cpu_selector_v };
 
   std::cout << "Selected device: " <<
     Q.get_device().get_info<info::device::name>() << "\n";

--- a/samples/Ch03_data_management/fig_3_10_in_order.cpp
+++ b/samples/Ch03_data_management/fig_3_10_in_order.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 4;
 

--- a/samples/Ch03_data_management/fig_3_11_depends_on.cpp
+++ b/samples/Ch03_data_management/fig_3_11_depends_on.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 4;
 

--- a/samples/Ch03_data_management/fig_3_13_read_after_write.cpp
+++ b/samples/Ch03_data_management/fig_3_13_read_after_write.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 using namespace sycl;
 constexpr int N = 42;

--- a/samples/Ch03_data_management/fig_3_15_write_after_read_and_write_after_write.cpp
+++ b/samples/Ch03_data_management/fig_3_15_write_after_read_and_write_after_write.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 using namespace sycl;
 constexpr int N = 42;

--- a/samples/Ch03_data_management/fig_3_4_usm_explicit_data_movement.cpp
+++ b/samples/Ch03_data_management/fig_3_4_usm_explicit_data_movement.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include<array>
 using namespace sycl;
 constexpr int N = 42;

--- a/samples/Ch03_data_management/fig_3_5_usm_implicit_data_movement.cpp
+++ b/samples/Ch03_data_management/fig_3_5_usm_implicit_data_movement.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch03_data_management/fig_3_6_buffers_and_accessors.cpp
+++ b/samples/Ch03_data_management/fig_3_6_buffers_and_accessors.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 using namespace sycl;
 constexpr int N = 42;

--- a/samples/Ch04_expressing_parallelism/fig_4_13_nd_range_matrix_multiply.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_13_nd_range_matrix_multiply.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 #include <random>

--- a/samples/Ch04_expressing_parallelism/fig_4_20_hierarchical_matrix_multiply.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_20_hierarchical_matrix_multiply.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 #include <random>

--- a/samples/Ch04_expressing_parallelism/fig_4_20_hierarchical_matrix_multiply.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_20_hierarchical_matrix_multiply.cpp
@@ -40,8 +40,8 @@ int main() {
       range num_groups{N / B, N / B}; // N is a multiple of B
       range group_size{B, B};
       h.parallel_for_work_group(num_groups, group_size, [=](group<2> grp) {
-        int jb = grp.get_id(0);
-        int ib = grp.get_id(1);
+        int jb = grp.get_group_id(0);
+        int ib = grp.get_group_id(1);
         grp.parallel_for_work_item([&](h_item<2> it) {
           int j = jb * B + it.get_local_id(0);
           int i = ib * B + it.get_local_id(1);

--- a/samples/Ch04_expressing_parallelism/fig_4_22_hierarchical_logical_matrix_multiply.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_22_hierarchical_logical_matrix_multiply.cpp
@@ -40,8 +40,8 @@ int main() {
       range num_groups{N / B, N / B}; // N is a multiple of B
       range group_size{B, B};
       h.parallel_for_work_group(num_groups, [=](group<2> grp) {
-        int jb = grp.get_id(0);
-        int ib = grp.get_id(1);
+        int jb = grp.get_group_id(0);
+        int ib = grp.get_group_id(1);
         grp.parallel_for_work_item(group_size, [&](h_item<2> it) {
           int j = jb * B + it.get_logical_local_id(0);
           int i = ib * B + it.get_logical_local_id(1);

--- a/samples/Ch04_expressing_parallelism/fig_4_22_hierarchical_logical_matrix_multiply.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_22_hierarchical_logical_matrix_multiply.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 #include <random>

--- a/samples/Ch04_expressing_parallelism/fig_4_5_vector_add.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_5_vector_add.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch04_expressing_parallelism/fig_4_6_matrix_add.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_6_matrix_add.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch04_expressing_parallelism/fig_4_7_basic_matrix_multiply.cpp
+++ b/samples/Ch04_expressing_parallelism/fig_4_7_basic_matrix_multiply.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 #include <random>

--- a/samples/Ch05_error_handling/fig_5_1_async_task_graph.cpp
+++ b/samples/Ch05_error_handling/fig_5_1_async_task_graph.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 

--- a/samples/Ch05_error_handling/fig_5_2_sync_error.cpp
+++ b/samples/Ch05_error_handling/fig_5_2_sync_error.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 int main() {

--- a/samples/Ch05_error_handling/fig_5_3_async_error.cpp
+++ b/samples/Ch05_error_handling/fig_5_3_async_error.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 // Our simple asynchronous handler function
@@ -22,8 +22,8 @@ void say_device(const queue& Q) {
 }
 
 int main() { 
-  queue Q1{ gpu_selector{}, handle_async_error };
-  queue Q2{ cpu_selector{}, handle_async_error };
+  queue Q1{ gpu_selector_v, handle_async_error };
+  queue Q2{ cpu_selector_v, handle_async_error };
   say_device(Q1);
   say_device(Q2);
 

--- a/samples/Ch05_error_handling/fig_5_6_catch_snip.cpp
+++ b/samples/Ch05_error_handling/fig_5_6_catch_snip.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 int main() { 

--- a/samples/Ch05_error_handling/fig_5_7_catch.cpp
+++ b/samples/Ch05_error_handling/fig_5_7_catch.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 int main() { 

--- a/samples/Ch05_error_handling/fig_5_8_lambda_handler.cpp
+++ b/samples/Ch05_error_handling/fig_5_8_lambda_handler.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 // BEGIN CODE SNIP
@@ -26,8 +26,8 @@ void say_device(const queue& Q) {
 }
 
 int main() { 
-  queue Q1{ gpu_selector{}, handle_async_error };
-  queue Q2{ cpu_selector{}, handle_async_error };
+  queue Q1{ gpu_selector_v, handle_async_error };
+  queue Q2{ cpu_selector_v, handle_async_error };
   say_device(Q1);
   say_device(Q2);
 

--- a/samples/Ch05_error_handling/fig_5_9_default_handler_proxy.cpp
+++ b/samples/Ch05_error_handling/fig_5_9_default_handler_proxy.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 // BEGIN CODE SNIP
@@ -29,8 +29,8 @@ void say_device(const queue& Q) {
 }
 
 int main() { 
-  queue Q1{ gpu_selector{}, handle_async_error };
-  queue Q2{ cpu_selector{}, handle_async_error };
+  queue Q1{ gpu_selector_v, handle_async_error };
+  queue Q2{ cpu_selector_v, handle_async_error };
   say_device(Q1);
   say_device(Q2);
 

--- a/samples/Ch06_unified_shared_memory/fig_6_5_allocation_styles.cpp
+++ b/samples/Ch06_unified_shared_memory/fig_6_5_allocation_styles.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch06_unified_shared_memory/fig_6_6_usm_explicit_data_movement.cpp
+++ b/samples/Ch06_unified_shared_memory/fig_6_6_usm_explicit_data_movement.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 using namespace sycl;
 constexpr int N = 42;

--- a/samples/Ch06_unified_shared_memory/fig_6_7_usm_implicit_data_movement.cpp
+++ b/samples/Ch06_unified_shared_memory/fig_6_7_usm_implicit_data_movement.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch06_unified_shared_memory/fig_6_8_prefetch_memadvise.cpp
+++ b/samples/Ch06_unified_shared_memory/fig_6_8_prefetch_memadvise.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 // Appropriate values depend on your HW

--- a/samples/Ch06_unified_shared_memory/fig_6_8_prefetch_memadvise.cpp
+++ b/samples/Ch06_unified_shared_memory/fig_6_8_prefetch_memadvise.cpp
@@ -23,7 +23,7 @@ int main() {
   // to the device instead of migrating it from the host.
   // Real values will be documented by your DPC++ backend.
   int HW_SPECIFIC_ADVICE_RO = 0;
-  Q.mem_advise(read_only_data, BLOCK_SIZE,(pi_mem_advice)HW_SPECIFIC_ADVICE_RO);
+  Q.mem_advise(read_only_data, BLOCK_SIZE, HW_SPECIFIC_ADVICE_RO);
   event e = Q.prefetch(data, BLOCK_SIZE);
 
   for (int b = 0; b < NUM_BLOCKS; b++) {

--- a/samples/Ch06_unified_shared_memory/fig_6_9_queries.cpp
+++ b/samples/Ch06_unified_shared_memory/fig_6_9_queries.cpp
@@ -2,9 +2,9 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
-using dinfo = info::device;
+namespace dinfo = info::device;
 constexpr int N = 42;
 
 template <typename T> void foo(T data, id<1> i) { data[i] = N; }

--- a/samples/Ch07_buffers/fig_7_10_accessors.cpp
+++ b/samples/Ch07_buffers/fig_7_10_accessors.cpp
@@ -18,9 +18,9 @@ int main() {
   accessor pC{C};
 
   Q.submit([&](handler &h) {
-      accessor aA{A, h, write_only, noinit};
-      accessor aB{B, h, write_only, noinit};
-      accessor aC{C, h, write_only, noinit};
+      accessor aA{A, h, write_only, no_init};
+      accessor aB{B, h, write_only, no_init};
+      accessor aC{C, h, write_only, no_init};
       h.parallel_for(N, [=](id<1> i) {
           aA[i] = 1;
           aB[i] = 40;

--- a/samples/Ch07_buffers/fig_7_10_accessors.cpp
+++ b/samples/Ch07_buffers/fig_7_10_accessors.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <cassert>
 using namespace sycl;
 constexpr int N = 42;

--- a/samples/Ch07_buffers/fig_7_2_3_4_creating_buffers.cpp
+++ b/samples/Ch07_buffers/fig_7_2_3_4_creating_buffers.cpp
@@ -2,12 +2,12 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 int main() {
   // Create a buffer of 2x5 ints using the default allocator
-  buffer<int, 2, buffer_allocator> b1{range<2>{2, 5}};
+  buffer<int, 2, buffer_allocator<int>> b1{range<2>{2, 5}};
 
   // Create a buffer of 2x5 ints using the default allocator and CTAD for range
   buffer<int, 2> b2{range{2, 5}};

--- a/samples/Ch07_buffers/fig_7_5_buffer_properties.cpp
+++ b/samples/Ch07_buffers/fig_7_5_buffer_properties.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <mutex>
 using namespace sycl;
 

--- a/samples/Ch07_buffers/fig_7_8_accessors_simple.cpp
+++ b/samples/Ch07_buffers/fig_7_8_accessors_simple.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch08_graph_scheduling/fig_8_3_linear_dependence_in_order.cpp
+++ b/samples/Ch08_graph_scheduling/fig_8_3_linear_dependence_in_order.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch08_graph_scheduling/fig_8_4_linear_dependence_events.cpp
+++ b/samples/Ch08_graph_scheduling/fig_8_4_linear_dependence_events.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch08_graph_scheduling/fig_8_5_linear_dependence_buffers.cpp
+++ b/samples/Ch08_graph_scheduling/fig_8_5_linear_dependence_buffers.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch08_graph_scheduling/fig_8_6_y_in_order.cpp
+++ b/samples/Ch08_graph_scheduling/fig_8_6_y_in_order.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch08_graph_scheduling/fig_8_7_y_events.cpp
+++ b/samples/Ch08_graph_scheduling/fig_8_7_y_events.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch08_graph_scheduling/fig_8_8_y_buffers.cpp
+++ b/samples/Ch08_graph_scheduling/fig_8_8_y_buffers.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 constexpr int N = 42;
 

--- a/samples/Ch09_work_item_communication/fig_9_10_hier_tiled_matmul.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_10_hier_tiled_matmul.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Ch09_work_item_communication/fig_9_11_sub_group_barrier.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_11_sub_group_barrier.cpp
@@ -28,7 +28,7 @@ int main() {
       h.parallel_for(nd_range{{size}, {16}}, [=](nd_item<1> item) {
         auto sg = item.get_sub_group();
         auto index = item.get_global_id();
-        sg.barrier();
+        group_barrier(sg);
         data_acc[index] = data_acc[index] + 1;
       });
 // END CODE SNIP

--- a/samples/Ch09_work_item_communication/fig_9_11_sub_group_barrier.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_11_sub_group_barrier.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch09_work_item_communication/fig_9_13_matmul_broadcast.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_13_matmul_broadcast.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 
@@ -42,9 +42,7 @@ double run_sycl(
 
       // Local accessor, for one matrix tile:
       constexpr int tile_size = 16;
-      auto tileA =
-          accessor<T, 1, access::mode::read_write, access::target::local>(
-              tile_size, h);
+      auto tileA = local_accessor<T, 1>(tile_size, h);
 
 // BEGIN CODE SNIP
       h.parallel_for(

--- a/samples/Ch09_work_item_communication/fig_9_13_matmul_broadcast.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_13_matmul_broadcast.cpp
@@ -62,7 +62,7 @@ double run_sycl(
               // to ensure all work-items have a consistent view
               // of the matrix tile in local memory.
               tileA[i] = matrixA[m][kk + i];
-              item.barrier();
+              group_barrier(item.get_group());
 
               // Perform computation using the local memory tile, and
               // matrix B in global memory.
@@ -75,7 +75,7 @@ double run_sycl(
 
               // After computation, synchronize again, to ensure all
               // reads from the local memory tile are complete.
-              item.barrier();
+              group_barrier(item.get_group());
             }
 
             // Write the final result to global memory.

--- a/samples/Ch09_work_item_communication/fig_9_14_ndrange_sub_group_matmul.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_14_ndrange_sub_group_matmul.cpp
@@ -64,7 +64,7 @@ double run_sycl(
               // variable k describes which work-item in the sub-group to
               // broadcast data from.
               for (int k = 0; k < tileSize; k++) {
-                sum += ONEAPI::broadcast(sg, tileA, k) * matrixB[kk + k][n];
+                sum += group_broadcast(sg, tileA, k) * matrixB[kk + k][n];
               }
             }
 

--- a/samples/Ch09_work_item_communication/fig_9_14_ndrange_sub_group_matmul.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_14_ndrange_sub_group_matmul.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Ch09_work_item_communication/fig_9_4_naive_matmul.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_4_naive_matmul.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Ch09_work_item_communication/fig_9_7_local_accessors.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_7_local_accessors.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -17,7 +17,7 @@ int main() {
   {
     buffer dataBuf{data};
 
-    queue Q{host_selector()};
+    queue Q{ default_selector_v };
     std::cout << "Running on device: "
               << Q.get_device().get_info<info::device::name>() << "\n";
 
@@ -27,14 +27,10 @@ int main() {
       accessor dataAcc {dataBuf, h};
 
       // This is a 1D local accessor consisting of 16 ints:
-      auto localIntAcc =
-          accessor<int, 1, access::mode::read_write, access::target::local>(
-              16, h);
+      auto localIntAcc = local_accessor<int, 1>(16, h);
 
       // This is a 2D local accessor consisting of 4 x 4 floats:
-      auto localFloatAcc =
-          accessor<float, 2, access::mode::read_write, access::target::local>(
-              {4, 4}, h);
+      auto localFloatAcc = local_accessor<float, 2>({4, 4}, h);
 
       h.parallel_for(nd_range<1>{{size}, {16}}, [=](nd_item<1> item) {
         auto index = item.get_global_id();

--- a/samples/Ch09_work_item_communication/fig_9_8_ndrange_tiled_matmul.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_8_ndrange_tiled_matmul.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 
@@ -43,9 +43,7 @@ double run_sycl(
 
       // Local accessor, for one matrix tile:
       constexpr int tile_size = 16;
-      auto tileA =
-          accessor<T, 1, access::mode::read_write, access::target::local>(
-              tile_size, h);
+      auto tileA = local_accessor<T, 1>(tile_size, h);
 
       h.parallel_for(
           nd_range<2>{{M, N}, {1, tile_size}}, [=](nd_item<2> item) {

--- a/samples/Ch09_work_item_communication/fig_9_8_ndrange_tiled_matmul.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_8_ndrange_tiled_matmul.cpp
@@ -62,7 +62,7 @@ double run_sycl(
               // to ensure all work-items have a consistent view
               // of the matrix tile in local memory.
               tileA[i] = matrixA[m][kk + i];
-              item.barrier();
+              group_barrier(item.get_group());
 
               // Perform computation using the local memory tile, and
               // matrix B in global memory.
@@ -72,7 +72,7 @@ double run_sycl(
 
               // After computation, synchronize again, to ensure all
               // reads from the local memory tile are complete.
-              item.barrier();
+              group_barrier(item.get_group());
             }
 
             // Write the final result to global memory.

--- a/samples/Ch09_work_item_communication/fig_9_9_local_hier.cpp
+++ b/samples/Ch09_work_item_communication/fig_9_9_local_hier.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch09_work_item_communication/matmul_harness.cpp
+++ b/samples/Ch09_work_item_communication/matmul_harness.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch10_expressing_kernels/fig_10_2_kernel_lambda.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_2_kernel_lambda.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -20,7 +20,7 @@ int main() {
   {
     buffer data_buf{data};
 
-    queue Q{ host_selector{} };
+    queue Q{ default_selector_v };
     std::cout << "Running on device: "
               << Q.get_device().get_info<info::device::name>() << "\n";
 

--- a/samples/Ch10_expressing_kernels/fig_10_3_optional_kernel_lambda_elements.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_3_optional_kernel_lambda_elements.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -20,7 +20,7 @@ int main() {
   {
     buffer data_buf{data};
 
-    queue Q{ host_selector{} };
+    queue Q{ default_selector_v };
     std::cout << "Running on device: "
               << Q.get_device().get_info<info::device::name>() << "\n";
 

--- a/samples/Ch10_expressing_kernels/fig_10_3_optional_kernel_lambda_elements.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_3_optional_kernel_lambda_elements.cpp
@@ -29,7 +29,7 @@ int main() {
       accessor data_acc {data_buf, h};
 
       h.parallel_for(size,
-          [=](id<1> i) noexcept [[cl::reqd_work_group_size(8,1,1)]] -> void {
+          [=](id<1> i) noexcept [[sycl::reqd_work_group_size(8,1,1)]] -> void {
             data_acc[i] = data_acc[i] + 1;
           });
     });

--- a/samples/Ch10_expressing_kernels/fig_10_4_named_kernel_lambda.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_4_named_kernel_lambda.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -18,7 +18,7 @@ int main() {
   {
     buffer data_buf{data};
 
-    queue Q{ host_selector{} };
+    queue Q{ default_selector_v };
     std::cout << "Running on device: "
               << Q.get_device().get_info<info::device::name>() << "\n";
 

--- a/samples/Ch10_expressing_kernels/fig_10_5_unnamed_kernel_lambda.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_5_unnamed_kernel_lambda.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -18,7 +18,7 @@ int main() {
   {
     buffer data_buf{data};
 
-    queue Q{ host_selector{} };
+    queue Q{ default_selector_v };
     std::cout << "Running on device: "
               << Q.get_device().get_info<info::device::name>() << "\n";
 

--- a/samples/Ch10_expressing_kernels/fig_10_6_kernel_functor.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_6_kernel_functor.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -30,7 +30,7 @@ int main() {
   {
     buffer data_buf{data};
 
-    queue Q{ host_selector{} };
+    queue Q{ default_selector_v };
     std::cout << "Running on device: "
               << Q.get_device().get_info<info::device::name>() << "\n";
 

--- a/samples/Ch10_expressing_kernels/fig_10_7_opencl_source_interop.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_7_opencl_source_interop.cpp
@@ -2,54 +2,8 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
-#include <array>
-#include <iostream>
-using namespace sycl;
-
-int main() {
-  constexpr size_t size = 16;
-  std::array<int, size> data;
-
-  for (int i = 0; i < size; i++) {
-    data[i] = i;
-  }
-
-  {
-    buffer data_buf{data};
-
-// BEGIN CODE SNIP
-    // Note: This must select a device that supports interop!
-    queue Q{ cpu_selector{} };
-
-    program p{Q.get_context()};
-    p.build_with_source(R"CLC(
-            kernel void add(global int* data) {
-                int index = get_global_id(0);
-                data[index] = data[index] + 1;
-            }
-        )CLC",
-        "-cl-fast-relaxed-math");
-
-    std::cout << "Running on device: "
-              << Q.get_device().get_info<info::device::name>() << "\n";
-
-    Q.submit([&](handler& h) {
-      accessor data_acc {data_buf, h};
-
-      h.set_args(data_acc);
-      h.parallel_for(size, p.get_kernel("add"));
-    });
-// END CODE SNIP
-  }
-
-  for (int i = 0; i < size; i++) {
-    if (data[i] != i + 1) {
-      std::cout << "Results did not validate at index " << i << "!\n";
-      return -1;
-    }
-  }
-
-  std::cout << "Success!\n";
-  return 0;
+// This example is no longer supported in SYCL2020, so it will be removed in a future edition of the book.  It remains as a placeholder file for now.
+int main()
+{
+	return 0;
 }

--- a/samples/Ch10_expressing_kernels/fig_10_8_opencl_object_interop.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_8_opencl_object_interop.cpp
@@ -2,9 +2,9 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <CL/cl.h>
-#include <CL/sycl/backend/opencl.hpp>
+#include <sycl/backend/opencl.hpp>
 #include <iostream>
 using namespace sycl;
 
@@ -22,7 +22,7 @@ int main() {
 // BEGIN CODE SNIP
     // Note: This must select a device that supports interop with OpenCL kernel
     // objects!
-    queue Q{ cpu_selector{} };
+    queue Q{ cpu_selector_v };
     context sc = Q.get_context();
 
     const char* kernelSource =

--- a/samples/Ch10_expressing_kernels/fig_10_9_kernel_lambda_build_options.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_9_kernel_lambda_build_options.cpp
@@ -25,18 +25,17 @@ int main() {
               << Q.get_device().get_info<info::device::name>() << "\n";
 
 // BEGIN CODE SNIP
-    // This compiles the kernel named by the specified template
-    // parameter using the "fast relaxed math" build option.
-    program p(Q.get_context());
-
-    p.build_with_kernel_type<class Add>("-cl-fast-relaxed-math");
+    kernel_id Add_KID = get_kernel_id<class Add>();
+    auto kb = get_kernel_bundle<bundle_state::executable>(Q.get_context(), {Add_KID});
+    kernel k = kb.get_kernel(Add_KID);
 
     Q.submit([&](handler& h) {
       accessor data_acc {data_buf, h};
 
       h.parallel_for<class Add>(
-          // This uses the previously compiled kernel.
-          p.get_kernel<class Add>(),
+          // This uses the previously compiled kernel k, the body of which is
+          // defined here as a lambda
+          k,
           range{size},
           [=](id<1> i) {
             data_acc[i] = data_acc[i] + 1;

--- a/samples/Ch10_expressing_kernels/fig_10_9_kernel_lambda_build_options.cpp
+++ b/samples/Ch10_expressing_kernels/fig_10_9_kernel_lambda_build_options.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -20,7 +20,7 @@ int main() {
   {
     buffer data_buf{data};
 
-    queue Q{ cpu_selector{} };
+    queue Q{ cpu_selector_v };
     std::cout << "Running on device: "
               << Q.get_device().get_info<info::device::name>() << "\n";
 

--- a/samples/Ch11_vectors/fig_11_6_load_store.cpp
+++ b/samples/Ch11_vectors/fig_11_6_load_store.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 #include<array>
-#include<CL/sycl.hpp>
+#include<sycl/sycl.hpp>
 using namespace sycl;
 
 int main() {

--- a/samples/Ch11_vectors/fig_11_7_swizzle_vec.cpp
+++ b/samples/Ch11_vectors/fig_11_7_swizzle_vec.cpp
@@ -4,7 +4,7 @@
 
 #define SYCL_SIMPLE_SWIZZLES
 #include <array>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 int main() {

--- a/samples/Ch11_vectors/fig_11_8_vector_exec.cpp
+++ b/samples/Ch11_vectors/fig_11_8_vector_exec.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 #include<array>
-#include<CL/sycl.hpp>
+#include<sycl/sycl.hpp>
 using namespace sycl;
 
 int main() {

--- a/samples/Ch12_device_information/fig_12_1_assigned_device.cpp
+++ b/samples/Ch12_device_information/fig_12_1_assigned_device.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 

--- a/samples/Ch12_device_information/fig_12_2_try_catch.cpp
+++ b/samples/Ch12_device_information/fig_12_2_try_catch.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 
@@ -12,13 +12,13 @@ int main() {
   auto GPU_is_available = false;
 
   try {
-    device testForGPU((gpu_selector()));
+    device testForGPU(gpu_selector_v);
     GPU_is_available = true;
   } catch (exception const& ex) {
     std::cout << "Caught this SYCL exception: " << ex.what() << std::endl;
   }
 
-  auto Q = GPU_is_available ? queue(gpu_selector()) : queue(host_selector());
+  auto Q = GPU_is_available ? queue(gpu_selector_v) : queue(default_selector_v);
 
   std::cout << "After checking for a GPU, we are running on:\n "
     << Q.get_device().get_info<info::device::name>() << "\n";
@@ -29,7 +29,7 @@ int main() {
   // 
   // sample output using a system with an FPGA accelerator, but no GPU:
   // Caught this SYCL exception: No device of requested type available.
-  // ...(CL_DEVICE_NOT_FOUND)
+  // ...(PI_ERROR_DEVICE_NOT_FOUND)
   // After checking for a GPU, we are running on:
   //  SYCL host device.
   //

--- a/samples/Ch12_device_information/fig_12_3_device_selector.cpp
+++ b/samples/Ch12_device_information/fig_12_3_device_selector.cpp
@@ -2,38 +2,37 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 
-class my_selector : public device_selector {
-  public:
-    int operator()(const device &dev) const {
-      int score = -1;
+int my_selector(const device &dev) {
+  int score = -1;
 
-      // We prefer non-Martian GPUs, especially ACME GPUs
-      if (dev.is_gpu()) {
-        if (dev.get_info<info::device::vendor>().find("ACME")
-            != std::string::npos) score += 25;
+  // We prefer non-Martian GPUs, especially ACME GPUs
+  if (dev.is_gpu()) {
+    if (dev.get_info<info::device::vendor>().find("ACME") != std::string::npos)
+      score += 25;
 
-        if (dev.get_info<info::device::vendor>().find("Martian")
-            == std::string::npos) score += 800;
-      }
+    if (dev.get_info<info::device::vendor>().find("Martian") ==
+        std::string::npos)
+      score += 800;
+  }
 
-      // Give host device points so it is used if no GPU is available.
-      // Without these next two lines, systems with no GPU would select
-      // nothing, since we initialize the score to a negative number above.
-      if (dev.is_host()) score += 100;
-
-      return score;
-    }
-};
+  // If there is no GPU on the system all devices will be given a negative score
+  // and the selector will not select a device. This will cause an exception.
+  return score;
+}
 
 int main() {
-  auto Q = queue{ my_selector{} };
-
-  std::cout << "After checking for a GPU, we are running on:\n "
-    << Q.get_device().get_info<info::device::name>() << "\n";
+  try {
+    auto Q = queue{ my_selector };
+    std::cout << "After checking for a GPU, we are running on:\n "
+              << Q.get_device().get_info<info::device::name>() << "\n";
+  } catch (exception const& ex) {
+    std::cout << "Custom device selector did not select a device.\n";
+    std::cout << "Caught this SYCL exception: " << ex.what() << std::endl;
+  }
 
   // Sample output using a system with a GPU:
   // After checking for a GPU, we are running on:
@@ -41,7 +40,9 @@ int main() {
   // 
   // Sample output using a system with an FPGA accelerator, but no GPU:
   // After checking for a GPU, we are running on:
-  //  SYCL host device.
+  //  Custom device selector did not select a device.
+  //  Caught this SYCL exception: No device of requested type available.
+  //  ...(PI_ERROR_DEVICE_NOT_FOUND)
 
   return 0;
 }

--- a/samples/Ch12_device_information/fig_12_4_curious.cpp
+++ b/samples/Ch12_device_information/fig_12_4_curious.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 

--- a/samples/Ch12_device_information/fig_12_6_very_curious.cpp
+++ b/samples/Ch12_device_information/fig_12_6_very_curious.cpp
@@ -2,14 +2,14 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 
-template <auto query, typename T>
+template <typename queryT, typename T>
 void do_query( const T& obj_to_query, const std::string& name, int indent=4) {
   std::cout << std::string(indent, ' ') << name << " is '"
-    << obj_to_query.template get_info<query>() << "'\n";
+    << obj_to_query.template get_info<queryT>() << "'\n";
 }
 
 
@@ -25,7 +25,6 @@ int main() {
     // Loop through the devices available in this plaform
     for (auto &dev : this_platform.get_devices() ) {
       std::cout << "  Device: " << dev.get_info<info::device::name>() << "\n";
-      std::cout << "    is_host(): " << (dev.is_host() ? "Yes" : "No") << "\n";
       std::cout << "    is_cpu(): " << (dev.is_cpu() ? "Yes" : "No") << "\n";
       std::cout << "    is_gpu(): " << (dev.is_gpu() ? "Yes" : "No") << "\n";
       std::cout << "    is_accelerator(): "

--- a/samples/Ch12_device_information/fig_12_7_invocation_parameters.cpp
+++ b/samples/Ch12_device_information/fig_12_7_invocation_parameters.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 using namespace sycl;
 

--- a/samples/Ch13_practical_tips/fig_13_10_host_accessor_deadlock.cpp
+++ b/samples/Ch13_practical_tips/fig_13_10_host_accessor_deadlock.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch13_practical_tips/fig_13_4_stream.cpp
+++ b/samples/Ch13_practical_tips/fig_13_4_stream.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include<CL/sycl.hpp>
+#include<sycl/sycl.hpp>
 #include<iostream>
 using namespace sycl;
 

--- a/samples/Ch13_practical_tips/fig_13_6_common_buffer_pattern.cpp
+++ b/samples/Ch13_practical_tips/fig_13_6_common_buffer_pattern.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch13_practical_tips/fig_13_7_common_pattern_bug.cpp
+++ b/samples/Ch13_practical_tips/fig_13_7_common_pattern_bug.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch13_practical_tips/fig_13_8_host_accessor.cpp
+++ b/samples/Ch13_practical_tips/fig_13_8_host_accessor.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch13_practical_tips/fig_13_9_host_accessor_for_init.cpp
+++ b/samples/Ch13_practical_tips/fig_13_9_host_accessor_for_init.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch14_common_parallel_patterns/fig_14_11_user_defined_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_11_user_defined_reduction.cpp
@@ -16,16 +16,7 @@
 using namespace sycl;
 
 template <typename T, typename I>
-struct pair {
-  bool operator<(const pair& o) const {
-    return val <= o.val || (val == o.val && idx <= o.idx);
-  }
-  T val;
-  I idx;
-};
-
-template <typename T, typename I>
-using minloc = sycl::ONEAPI::minimum<pair<T, I>>;
+using minloc = sycl::minimum<std::pair<T, I>>;
 
 int main() {
   constexpr size_t N = 16;
@@ -33,10 +24,10 @@ int main() {
 
   queue Q;
   float* data = malloc_shared<float>(N, Q);
-  pair<float, int>* res = malloc_shared<pair<float, int>>(1, Q);
+  std::pair<float, int>* res = malloc_shared<std::pair<float, int>>(1, Q);
   std::generate(data, data + N, std::mt19937{});
 
-  pair<float, int> identity = {
+  std::pair<float, int> identity = {
       std::numeric_limits<float>::max(), std::numeric_limits<int>::min()};
   *res = identity;
 
@@ -45,21 +36,21 @@ int main() {
   Q.submit([&](handler& h) {
      h.parallel_for(nd_range<1>{N, L}, red, [=](nd_item<1> item, auto& res) {
        int i = item.get_global_id(0);
-       pair<float, int> partial = {data[i], i};
+       std::pair<float, int> partial = {data[i], i};
        res.combine(partial);
      });
    }).wait();
 
-  std::cout << "minimum value = " << res->val << " at " << res->idx << "\n";
+  std::cout << "minimum value = " << res->first << " at " << res->second << "\n";
 
-  pair<float, int> gold = identity;
+  std::pair<float, int> gold = identity;
   for (int i = 0; i < N; ++i) {
-    if (data[i] <= gold.val || (data[i] == gold.val && i < gold.idx)) {
-      gold.val = data[i];
-      gold.idx = i;
+    if (data[i] <= gold.first || (data[i] == gold.first && i < gold.second)) {
+      gold.first = data[i];
+      gold.second = i;
     }
   }
-  bool passed = (res->val == gold.val) && (res->idx == gold.idx);
+  bool passed = (res->first == gold.first) && (res->second == gold.second);
   std::cout << ((passed) ? "SUCCESS" : "FAILURE") << "\n";
 
   free(res, Q);

--- a/samples/Ch14_common_parallel_patterns/fig_14_11_user_defined_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_11_user_defined_reduction.cpp
@@ -9,7 +9,7 @@
 //   added sycl::ONEAPI:: to minimum.
 // -------------------------------------------------------
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <random>
 

--- a/samples/Ch14_common_parallel_patterns/fig_14_13_map.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_13_map.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>

--- a/samples/Ch14_common_parallel_patterns/fig_14_14_stencil.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_14_stencil.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>

--- a/samples/Ch14_common_parallel_patterns/fig_14_15_local_stencil.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_15_local_stencil.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
@@ -11,10 +11,6 @@
 #include <random>
 
 using namespace sycl;
-
-template <typename T, int dimensions>
-using local_accessor =
-    accessor<T, dimensions, access::mode::read_write, access::target::local>;
 
 int main() {
   queue Q;

--- a/samples/Ch14_common_parallel_patterns/fig_14_15_local_stencil.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_15_local_stencil.cpp
@@ -54,7 +54,7 @@ int main() {
                 tile[ti][tj] = input[gi][gj];
               }
             }
-            it.barrier(access::fence_space::local_space);
+            group_barrier(it.get_group());
 
             // Compute the stencil using values from local memory
             int gi = it.get_global_id(0) + 1;

--- a/samples/Ch14_common_parallel_patterns/fig_14_16_basic_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_16_basic_reduction.cpp
@@ -9,10 +9,6 @@
 using namespace sycl;
 
 int main() {
-
-  using memory_order = sycl::memory_order;
-  using memory_scope = sycl::memory_scope;
-
   constexpr size_t N = 16;
 
   queue Q;

--- a/samples/Ch14_common_parallel_patterns/fig_14_16_basic_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_16_basic_reduction.cpp
@@ -7,12 +7,11 @@
 #include <numeric>
 
 using namespace sycl;
-using namespace sycl::ONEAPI;
 
 int main() {
 
-  using memory_order = sycl::ONEAPI::memory_order;
-  using memory_scope = sycl::ONEAPI::memory_scope;
+  using memory_order = sycl::memory_order;
+  using memory_scope = sycl::memory_scope;
 
   constexpr size_t N = 16;
 

--- a/samples/Ch14_common_parallel_patterns/fig_14_16_basic_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_16_basic_reduction.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <numeric>
 

--- a/samples/Ch14_common_parallel_patterns/fig_14_17_nd_range_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_17_nd_range_reduction.cpp
@@ -9,10 +9,6 @@
 using namespace sycl;
 
 int main() {
-
-  using memory_order = sycl::memory_order;
-  using memory_scope = sycl::memory_scope;
-
   constexpr size_t N = 16;
   constexpr size_t B = 4;
 

--- a/samples/Ch14_common_parallel_patterns/fig_14_17_nd_range_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_17_nd_range_reduction.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <cstdio>
 #include <numeric>
 

--- a/samples/Ch14_common_parallel_patterns/fig_14_17_nd_range_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_17_nd_range_reduction.cpp
@@ -7,12 +7,11 @@
 #include <numeric>
 
 using namespace sycl;
-using namespace sycl::ONEAPI;
 
 int main() {
 
-  using memory_order = sycl::ONEAPI::memory_order;
-  using memory_scope = sycl::ONEAPI::memory_scope;
+  using memory_order = sycl::memory_order;
+  using memory_scope = sycl::memory_scope;
 
   constexpr size_t N = 16;
   constexpr size_t B = 4;
@@ -25,7 +24,7 @@ int main() {
 
   Q.parallel_for(nd_range<1>{N, B}, [=](nd_item<1> it) {
      int i = it.get_global_id(0);
-     int group_sum = reduce(it.get_group(), data[i], plus<>());
+     int group_sum = reduce_over_group(it.get_group(), data[i], plus<>());
      if (it.get_local_id(0) == 0) {
        atomic_ref<
            int,

--- a/samples/Ch14_common_parallel_patterns/fig_14_18-20_inclusive_scan.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_18-20_inclusive_scan.cpp
@@ -40,15 +40,15 @@ int main() {
 
        // Copy input to local memory
        local[li] = input[i];
-       it.barrier();
+       group_barrier(it.get_group());
 
        // Perform inclusive scan in local memory
        for (int32_t d = 0; d <= log2((float)L) - 1; ++d) {
          uint32_t stride = (1 << d);
          int32_t update = (li >= stride) ? local[li - stride] : 0;
-         it.barrier();
+         group_barrier(it.get_group());
          local[li] += update;
-         it.barrier();
+         group_barrier(it.get_group());
        }
 
        // Write the result for each item to the output buffer
@@ -69,15 +69,15 @@ int main() {
 
        // Copy input to local memory
        local[li] = tmp[i];
-       it.barrier();
+       group_barrier(it.get_group());
 
        // Perform inclusive scan in local memory
        for (int32_t d = 0; d <= log2((float)G) - 1; ++d) {
          uint32_t stride = (1 << d);
          int32_t update = (li >= stride) ? local[li - stride] : 0;
-         it.barrier();
+         group_barrier(it.get_group());
          local[li] += update;
-         it.barrier();
+         group_barrier(it.get_group());
        }
 
        // Overwrite result from each work-item in the temporary buffer

--- a/samples/Ch14_common_parallel_patterns/fig_14_18-20_inclusive_scan.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_18-20_inclusive_scan.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
@@ -11,10 +11,6 @@
 #include <random>
 
 using namespace sycl;
-
-template <typename T, int dimensions>
-using local_accessor =
-    accessor<T, dimensions, access::mode::read_write, access::target::local>;
 
 int main() {
   queue q;

--- a/samples/Ch14_common_parallel_patterns/fig_14_22_local_pack.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_22_local_pack.cpp
@@ -57,15 +57,15 @@ int main() {
 
            // Pack neighbors that require post-processing into a list
            uint32_t pack = (i != j) and (r <= CUTOFF);
-           uint32_t offset = exclusive_scan(sg, pack, plus<>());
+           uint32_t offset = exclusive_scan_over_group(sg, pack, plus<>());
            if (pack) {
              neighbors[i * MAX_K + k + offset] = j;
            }
 
            // Keep track of how many neighbors have been packed so far
-           k += reduce(sg, pack, plus<>());
+           k += reduce_over_group(sg, pack, plus<>());
          }
-         num_neighbors[i] = reduce(sg, k, maximum<>());
+         num_neighbors[i] = reduce_over_group(sg, k, maximum<>());
        })
       .wait();
 

--- a/samples/Ch14_common_parallel_patterns/fig_14_22_local_pack.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_22_local_pack.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
@@ -11,10 +11,6 @@
 #include <random>
 
 using namespace sycl;
-
-template <typename T, int dimensions>
-using local_accessor =
-    accessor<T, dimensions, access::mode::read_write, access::target::local>;
 
 int main() {
   queue Q;

--- a/samples/Ch14_common_parallel_patterns/fig_14_22_local_pack.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_22_local_pack.cpp
@@ -11,7 +11,6 @@
 #include <random>
 
 using namespace sycl;
-using namespace sycl::ONEAPI;
 
 template <typename T, int dimensions>
 using local_accessor =

--- a/samples/Ch14_common_parallel_patterns/fig_14_24_local_unpack.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_24_local_unpack.cpp
@@ -13,7 +13,6 @@
 #include <random>
 
 using namespace sycl;
-using namespace sycl::ONEAPI;
 
 const uint32_t max_iterations = 1024;
 const uint32_t Nx = 1024, Ny = 768;

--- a/samples/Ch14_common_parallel_patterns/fig_14_24_local_unpack.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_24_local_unpack.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <complex>
 #include <cstdio>

--- a/samples/Ch14_common_parallel_patterns/fig_14_24_local_unpack.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_24_local_unpack.cpp
@@ -118,16 +118,16 @@ int main() {
         }
 
         // Keep iterating as long as one work-item has work to do
-        while (any_of(sg, i < Nx)) {
+        while (any_of_group(sg, i < Nx)) {
           uint32_t converged =
               next_iteration(params, i, j, count, cr, ci, zr, zi, mandelbrot);
-          if (any_of(sg, converged)) {
+          if (any_of_group(sg, converged)) {
 
             // Replace pixels that have converged using an unpack
             // Pixels that haven't converged are not replaced
-            uint32_t index = exclusive_scan(sg, converged, plus<>());
+            uint32_t index = exclusive_scan_over_group(sg, converged, plus<>());
             i = (converged) ? iq + index : i;
-            iq += reduce(sg, converged, plus<>());
+            iq += reduce_over_group(sg, converged, plus<>());
 
             // Reset the iterator variables for the new i
             if (converged) {

--- a/samples/Ch14_common_parallel_patterns/fig_14_8_one_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_8_one_reduction.cpp
@@ -30,7 +30,7 @@ int main() {
 // BEGIN CODE SNIP
      h.parallel_for(
          nd_range<1>{N, B},
-         reduction(sum, sycl::ONEAPI::plus<>()),
+         reduction(sum, sycl::plus<>()),
          [=](nd_item<1> it, auto& sum) {
            int i = it.get_global_id(0);
            sum += data[i];

--- a/samples/Ch14_common_parallel_patterns/fig_14_8_one_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_8_one_reduction.cpp
@@ -9,7 +9,7 @@
 //   added sycl::ONEAPI:: to plus
 // -------------------------------------------------------
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <numeric>
 

--- a/samples/Ch15_gpus/fig_15_10_divergent_control_flow.cpp
+++ b/samples/Ch15_gpus/fig_15_10_divergent_control_flow.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 using namespace sycl;
@@ -17,7 +17,7 @@ int main() {
 
   buffer dataBuf{data};
 
-  queue Q{ host_selector{} };
+  queue Q{ default_selector_v };
   Q.submit([&](handler& h) {
       accessor dataAcc{ dataBuf, h };
 

--- a/samples/Ch15_gpus/fig_15_12_small_work_group_matrix_multiplication.cpp
+++ b/samples/Ch15_gpus/fig_15_12_small_work_group_matrix_multiplication.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Ch15_gpus/fig_15_18_columns_matrix_multiplication.cpp
+++ b/samples/Ch15_gpus/fig_15_18_columns_matrix_multiplication.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Ch15_gpus/fig_15_3_single_task_matrix_multiplication.cpp
+++ b/samples/Ch15_gpus/fig_15_3_single_task_matrix_multiplication.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Ch15_gpus/fig_15_5_somewhat_parallel_matrix_multiplication.cpp
+++ b/samples/Ch15_gpus/fig_15_5_somewhat_parallel_matrix_multiplication.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Ch15_gpus/fig_15_7_more_parallel_matrix_multiplication.cpp
+++ b/samples/Ch15_gpus/fig_15_7_more_parallel_matrix_multiplication.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Ch15_gpus/matrix_multiplication_harness.cpp
+++ b/samples/Ch15_gpus/matrix_multiplication_harness.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 using namespace sycl;

--- a/samples/Ch16_cpus/fig_16_12_forward_dep.cpp
+++ b/samples/Ch16_cpus/fig_16_12_forward_dep.cpp
@@ -32,10 +32,10 @@ int main()
       // load a[i*n+j+1:8] before updating a[i*n+j:8] to preserve
       // loop-carried forward dependency
       auto va = a[i*n + j + 1];
-      sg.barrier();
+      group_barrier(sg);
       a[i*n + j] = va + i + 2;
     }
-    sg.barrier();
+    group_barrier(sg);
 
   }).wait();
 

--- a/samples/Ch16_cpus/fig_16_12_forward_dep.cpp
+++ b/samples/Ch16_cpus/fig_16_12_forward_dep.cpp
@@ -21,7 +21,7 @@ int main()
     for (int j = 0; j < n+1; j++) a[i*n + j] = i + j;
 
   Q.parallel_for(nd_range<2>{G, L}, [=](nd_item<2> it)
-    [[intel::reqd_sub_group_size(w)]] {
+    [[sycl::reqd_sub_group_size(w)]] {
 
     // distribute uniform "i" over the sub-group with 8-way
     // redundant computation

--- a/samples/Ch16_cpus/fig_16_12_forward_dep.cpp
+++ b/samples/Ch16_cpus/fig_16_12_forward_dep.cpp
@@ -6,7 +6,6 @@
 #include <iostream>
 
 using namespace sycl;
-using namespace sycl::ONEAPI;
 
 int main()
 {

--- a/samples/Ch16_cpus/fig_16_12_forward_dep.cpp
+++ b/samples/Ch16_cpus/fig_16_12_forward_dep.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 
 using namespace sycl;

--- a/samples/Ch16_cpus/fig_16_18_vector_swizzle.cpp
+++ b/samples/Ch16_cpus/fig_16_18_vector_swizzle.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 #define SYCL_SIMPLE_SWIZZLES
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 
 using namespace sycl;

--- a/samples/Ch16_cpus/fig_16_18_vector_swizzle.cpp
+++ b/samples/Ch16_cpus/fig_16_18_vector_swizzle.cpp
@@ -7,7 +7,6 @@
 #include <iostream>
 
 using namespace sycl;
-using namespace sycl::INTEL;
 
 int main() {
   queue Q;

--- a/samples/Ch16_cpus/fig_16_6_stream_triad.cpp
+++ b/samples/Ch16_cpus/fig_16_6_stream_triad.cpp
@@ -14,9 +14,9 @@ constexpr int num_runs = 10;
 constexpr size_t scalar = 3;
 
 double triad(
-    const std::vector<double>& vecA,
-    const std::vector<double>& vecB,
-    std::vector<double>& vecC ) {
+    const std::vector<float>& vecA,
+    const std::vector<float>& vecB,
+    std::vector<float>& vecC ) {
 
   assert(vecA.size() == vecB.size() && vecB.size() == vecC.size());
   const size_t array_size = vecA.size();
@@ -25,9 +25,9 @@ double triad(
   queue Q{ property::queue::enable_profiling{} };
   std::cout << "Running on device: " << Q.get_device().get_info<info::device::name>() << "\n";
 
-  buffer<double> bufA(vecA);
-  buffer<double> bufB(vecB);
-  buffer<double> bufC(vecC);
+  buffer<float> bufA(vecA);
+  buffer<float> bufB(vecB);
+  buffer<float> bufC(vecC);
 
   for (int i = 0; i< num_runs; i++) {
     auto Q_event = Q.submit([&](handler& h) {
@@ -63,11 +63,11 @@ int main(int argc, char *argv[]) {
   }
 
   std::cout << "Running with stream size of " << array_size
-    << " elements (" << (array_size * sizeof(double))/(double)1024/1024 << "MB)\n";
+    << " elements (" << (array_size * sizeof(float))/(double)1024/1024 << "MB)\n";
 
-  std::vector<double> D(array_size, 1.0);
-  std::vector<double> E(array_size, 2.0);
-  std::vector<double> F(array_size, 0.0);
+  std::vector<float> D(array_size, 1.0);
+  std::vector<float> E(array_size, 2.0);
+  std::vector<float> F(array_size, 0.0);
 
   double min_time = triad(D, E, F);
 
@@ -80,7 +80,7 @@ int main(int argc, char *argv[]) {
   }
   std::cout << "Results are correct!\n\n";
 
-  size_t triad_bytes = 3 * sizeof(double) * array_size;
+  size_t triad_bytes = 3 * sizeof(float) * array_size;
   std::cout << "Triad Bytes: " << triad_bytes << "\n";
   std::cout << "Time in sec (fastest run): " << min_time * 1.0E-9 << "\n";
 

--- a/samples/Ch16_cpus/fig_16_6_stream_triad.cpp
+++ b/samples/Ch16_cpus/fig_16_6_stream_triad.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <cassert>
 #include <cfloat>

--- a/samples/Ch17_fpgas/fig_17_11_fpga_emulator_selector.cpp
+++ b/samples/Ch17_fpgas/fig_17_11_fpga_emulator_selector.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_selector
 using namespace sycl;
 

--- a/samples/Ch17_fpgas/fig_17_17_ndrange_func.cpp
+++ b/samples/Ch17_fpgas/fig_17_17_ndrange_func.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_emulator_selector
 using namespace sycl;
 

--- a/samples/Ch17_fpgas/fig_17_18_loop_func.cpp
+++ b/samples/Ch17_fpgas/fig_17_18_loop_func.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_emulator_selector
 using namespace sycl;
 

--- a/samples/Ch17_fpgas/fig_17_20_loop_carried_deps.cpp
+++ b/samples/Ch17_fpgas/fig_17_20_loop_carried_deps.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_emulator_selector
 using namespace sycl;
 

--- a/samples/Ch17_fpgas/fig_17_22_loop_carried_state.cpp
+++ b/samples/Ch17_fpgas/fig_17_22_loop_carried_state.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_emulator_selector
 using namespace sycl;
 

--- a/samples/Ch17_fpgas/fig_17_31_inter_kernel_pipe.cpp
+++ b/samples/Ch17_fpgas/fig_17_31_inter_kernel_pipe.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_emulator_selector
 #include <array>
 using namespace sycl;

--- a/samples/Ch17_fpgas/fig_17_9_fpga_selector.cpp
+++ b/samples/Ch17_fpgas/fig_17_9_fpga_selector.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp> // For fpga_selector
 using namespace sycl;
 

--- a/samples/Ch18_using_libs/fig_18_11_std_fill.cpp
+++ b/samples/Ch18_using_libs/fig_18_11_std_fill.cpp
@@ -10,7 +10,7 @@
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/iterator>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 int main(){
   sycl::queue Q;

--- a/samples/Ch18_using_libs/fig_18_13_binary_search.cpp
+++ b/samples/Ch18_using_libs/fig_18_13_binary_search.cpp
@@ -14,7 +14,7 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/iterator>
 #include <iostream>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 using namespace sycl;
 

--- a/samples/Ch18_using_libs/fig_18_13_binary_search.cpp
+++ b/samples/Ch18_using_libs/fig_18_13_binary_search.cpp
@@ -24,8 +24,8 @@ int main()
     buffer<uint64_t, 1> vB{ range<1>(5) };
     buffer<uint64_t, 1> rB{ range<1>(5) };
     {
-      accessor k{kB};
-      accessor v{vB};
+      host_accessor k{kB};
+      host_accessor v{vB};
 
       // Initialize data, sorted
       k[0] = 0; k[1] = 5; k[2] = 6; k[3] = 6; k[4] = 7;

--- a/samples/Ch18_using_libs/fig_18_13_binary_search.cpp
+++ b/samples/Ch18_using_libs/fig_18_13_binary_search.cpp
@@ -48,7 +48,7 @@ int main()
     oneapi::dpl::binary_search(policy, k_beg, k_end, v_beg, v_end, r_beg);
 
     // check data
-    accessor r{rB};
+    host_accessor r{rB};
     if ((r[0] == false) && (r[1] == true) && (r[2] == false) && (r[3] == true) && (r[4] == true)) {
        std::cout << "Passed. \nRun on "
             << policy.queue().get_device().get_info<info::device::name>() << "\n";

--- a/samples/Ch18_using_libs/fig_18_15_pstl_usm.cpp
+++ b/samples/Ch18_using_libs/fig_18_15_pstl_usm.cpp
@@ -9,7 +9,7 @@
 
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 int main(){
   sycl::queue Q;

--- a/samples/Ch18_using_libs/fig_18_1_builtin.cpp
+++ b/samples/Ch18_using_libs/fig_18_1_builtin.cpp
@@ -10,8 +10,8 @@ using namespace sycl;
 
 int main() {
   constexpr int size = 9;
-  std::array<double, size> A;
-  std::array<double, size> B;
+  std::array<float, size> A;
+  std::array<float, size> B;
 
   bool pass = true;
 
@@ -21,8 +21,8 @@ int main() {
 
   range sz{size};
 
-  buffer<double> bufA(A);
-  buffer<double> bufB(B);
+  buffer<float> bufA(A);
+  buffer<float> bufB(B);
   buffer<bool>   bufP(&pass, 1);
 
   Q.submit([&](handler &h) {
@@ -42,7 +42,7 @@ int main() {
   host_accessor host_A(bufA);
   host_accessor host_P(bufP);
 
-  if (host_P[0] && host_A[4] == std::log(4.00)) {
+  if (host_P[0] && host_A[4] == std::log(4.00f)) {
     std::cout << "Passed\n";
   } else {
     std::cout << "Failed\n";

--- a/samples/Ch18_using_libs/fig_18_1_builtin.cpp
+++ b/samples/Ch18_using_libs/fig_18_1_builtin.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <cmath>
 #include <iostream>

--- a/samples/Ch18_using_libs/fig_18_7_swap.cpp
+++ b/samples/Ch18_using_libs/fig_18_7_swap.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <array>
 #include <iostream>
 #include <utility>

--- a/samples/Ch19_memory_model_and_atomics/fig_19_15_buffer_and_atomic_ref.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_15_buffer_and_atomic_ref.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 

--- a/samples/Ch19_memory_model_and_atomics/fig_19_15_buffer_and_atomic_ref.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_15_buffer_and_atomic_ref.cpp
@@ -9,10 +9,6 @@
 using namespace sycl;
 
 int main() {
-
-  using memory_order = sycl::memory_order;
-  using memory_scope = sycl::memory_scope;
-
   queue Q;
 
   const size_t N = 32;

--- a/samples/Ch19_memory_model_and_atomics/fig_19_15_buffer_and_atomic_ref.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_15_buffer_and_atomic_ref.cpp
@@ -7,12 +7,11 @@
 #include <iostream>
 
 using namespace sycl;
-using namespace sycl::ONEAPI;
 
 int main() {
 
-  using memory_order = sycl::ONEAPI::memory_order;
-  using memory_scope = sycl::ONEAPI::memory_scope;
+  using memory_order = sycl::memory_order;
+  using memory_scope = sycl::memory_scope;
 
   queue Q;
 

--- a/samples/Ch19_memory_model_and_atomics/fig_19_16_atomic_accessor.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_16_atomic_accessor.cpp
@@ -2,49 +2,9 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
-#include <algorithm>
-#include <iostream>
 
-using namespace sycl;
-using namespace sycl::ONEAPI;
-
+// Empty pending decision on how to represent this example, or whether to remove
 int main() {
-  queue Q;
-
-  const size_t N = 32;
-  const size_t M = 4;
-  std::vector<int> data(N);
-  std::fill(data.begin(), data.end(), 0);
-  {
-    buffer buf(data);
-
-    Q.submit([&](handler& h) {
-      atomic_accessor acc(buf, h, relaxed_order, system_scope);
-      h.parallel_for(N, [=](id<1> i) {
-        int j = i % M;
-        acc[j] += 1;
-      });
-    });
-  }
-
-  for (int i = 0; i < N; ++i) {
-    std::cout << "data [" << i << "] = " << data[i] << "\n";
-  }
-
-  bool passed = true;
-  int* gold = (int*) malloc(N * sizeof(int));
-  std::fill(gold, gold + N, 0);
-  for (int i = 0; i < N; ++i) {
-    int j = i % M;
-    gold[j] += 1;
-  }
-  for (int i = 0; i < N; ++i) {
-    if (data[i] != gold[i]) {
-      passed = false;
-    }
-  }
-  std::cout << ((passed) ? "SUCCESS\n" : "FAILURE\n");
-  free(gold);
-  return (passed) ? 0 : 1;
+	return 0;
 }
+

--- a/samples/Ch19_memory_model_and_atomics/fig_19_18_histogram.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_18_histogram.cpp
@@ -2,17 +2,13 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <cstdio>
 #include <numeric>
 #include <random>
 
 using namespace sycl;
-
-template <typename T, int dimensions>
-using local_accessor =
-    accessor<T, dimensions, access::mode::read_write, access::target::local>;
 
 std::tuple<size_t, size_t> distribute_range(group<1> g, size_t N) {
   size_t work_per_group = N / g.get_group_range(0);

--- a/samples/Ch19_memory_model_and_atomics/fig_19_18_histogram.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_18_histogram.cpp
@@ -9,7 +9,6 @@
 #include <random>
 
 using namespace sycl;
-using namespace sycl::ONEAPI;
 
 template <typename T, int dimensions>
 using local_accessor =
@@ -27,8 +26,8 @@ std::tuple<size_t, size_t> distribute_range(group<1> g, size_t N) {
 
 // Define shorthand aliases for the types of atomic needed by this kernel
 namespace {
-  using memory_order = ONEAPI::memory_order;
-  using memory_scope = ONEAPI::memory_scope;
+  using memory_order = memory_order;
+  using memory_scope = memory_scope;
 
   template <typename T>
   using local_atomic_ref = atomic_ref<

--- a/samples/Ch19_memory_model_and_atomics/fig_19_19-20_device_latch.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_19-20_device_latch.cpp
@@ -7,11 +7,10 @@
 #include <cstdio>
 
 using namespace sycl;
-using namespace sycl::ONEAPI;
 
 struct device_latch {
-  using memory_order = ONEAPI::memory_order;
-  using memory_scope = ONEAPI::memory_scope;
+  using memory_order = memory_order;
+  using memory_scope = memory_scope;
 
   explicit device_latch(size_t num_groups) : counter(0), expected(num_groups) {}
 

--- a/samples/Ch19_memory_model_and_atomics/fig_19_19-20_device_latch.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_19-20_device_latch.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <cassert>
 #include <cstdio>
 

--- a/samples/Ch19_memory_model_and_atomics/fig_19_3_data_race.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_3_data_race.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 

--- a/samples/Ch19_memory_model_and_atomics/fig_19_6_avoid_data_race_with_barrier.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_6_avoid_data_race_with_barrier.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 

--- a/samples/Ch19_memory_model_and_atomics/fig_19_6_avoid_data_race_with_barrier.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_6_avoid_data_race_with_barrier.cpp
@@ -30,7 +30,7 @@ int main() {
        if (i == round) {
          data[j] += 1;
        }
-       it.barrier();
+       group_barrier(it.get_group());
      }
    }).wait();
 

--- a/samples/Ch19_memory_model_and_atomics/fig_19_7_avoid_data_race_with_atomics.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_7_avoid_data_race_with_atomics.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <iostream>
 

--- a/samples/Ch19_memory_model_and_atomics/fig_19_7_avoid_data_race_with_atomics.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_7_avoid_data_race_with_atomics.cpp
@@ -9,10 +9,6 @@
 using namespace sycl;
 
 int main() {
-
-  using memory_order = sycl::memory_order;
-  using memory_scope = sycl::memory_scope;
-
   queue Q;
 
   const size_t N = 32;

--- a/samples/Ch19_memory_model_and_atomics/fig_19_7_avoid_data_race_with_atomics.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_7_avoid_data_race_with_atomics.cpp
@@ -7,12 +7,11 @@
 #include <iostream>
 
 using namespace sycl;
-using namespace sycl::ONEAPI;
 
 int main() {
 
-  using memory_order = sycl::ONEAPI::memory_order;
-  using memory_scope = sycl::ONEAPI::memory_scope;
+  using memory_order = sycl::memory_order;
+  using memory_scope = sycl::memory_scope;
 
   queue Q;
 

--- a/samples/Epilogue_future_direction/fig_ep_1_mdspan.cpp
+++ b/samples/Epilogue_future_direction/fig_ep_1_mdspan.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <experimental/mdspan>
 
 using namespace sycl;

--- a/samples/Epilogue_future_direction/fig_ep_2-4_generic_space.cpp
+++ b/samples/Epilogue_future_direction/fig_ep_2-4_generic_space.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 using namespace sycl;
 

--- a/samples/Epilogue_future_direction/fig_ep_5_extension_mechanism.cpp
+++ b/samples/Epilogue_future_direction/fig_ep_5_extension_mechanism.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 using namespace sycl;
 

--- a/samples/Epilogue_future_direction/fig_ep_6_device_constexpr.cpp
+++ b/samples/Epilogue_future_direction/fig_ep_6_device_constexpr.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 using namespace sycl;
 

--- a/samples/Epilogue_future_direction/fig_ep_7_hierarchical_reduction.cpp
+++ b/samples/Epilogue_future_direction/fig_ep_7_hierarchical_reduction.cpp
@@ -7,7 +7,6 @@
 #include <numeric>
 
 using namespace sycl;
-using namespace sycl::ONEAPI;
 
 int main() {
 

--- a/samples/Epilogue_future_direction/fig_ep_7_hierarchical_reduction.cpp
+++ b/samples/Epilogue_future_direction/fig_ep_7_hierarchical_reduction.cpp
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <numeric>
 


### PR DESCRIPTION
Most current toolchains align with SYCL 2020 features, so it's confusing that the mainline branch of this repo is older SYCL 1.2.1 code.  This PR collapses the SYCL2020 updates branch to mainline, and the SYCL 1.2.1 code corresponding to the First Edition of the book is now maintained on the [sycl121_original_publication branch.](https://github.com/Apress/data-parallel-CPP/tree/sycl121_original_publication)