### PR TITLE
Duplicate Figure 19-7 as Figure 19-17

### DIFF
--- a/samples/Ch19_memory_model_and_atomics/CMakeLists.txt
+++ b/samples/Ch19_memory_model_and_atomics/CMakeLists.txt
@@ -28,6 +28,11 @@ add_book_sample(
 
 add_book_sample(
     TEST
+    TARGET fig_19_17_usm_and_atomic_ref
+    SOURCES fig_19_17_usm_and_atomic_ref.cpp)
+
+add_book_sample(
+    TEST
     TARGET fig_19_18_histogram
     SOURCES fig_19_18_histogram.cpp)
 

--- a/samples/Ch19_memory_model_and_atomics/fig_19_17_usm_and_atomic_ref.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_17_usm_and_atomic_ref.cpp
@@ -4,7 +4,7 @@
 
 // The contents of this file are identical to
 // fig_19_7_avoid_data_race_with_atomics.cpp.
-// The figures is reproduced in the book for readability,
+// The figure is reproduced in the book for readability,
 // and duplicated here to avoid confusion.
 
 #include <sycl/sycl.hpp>

--- a/samples/Ch19_memory_model_and_atomics/fig_19_17_usm_and_atomic_ref.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_17_usm_and_atomic_ref.cpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2020 Intel Corporation
+
+// SPDX-License-Identifier: MIT
+
+// The contents of this file are identical to
+// fig_19_7_avoid_data_race_with_atomics.cpp.
+// The figures is reproduced in the book for readability,
+// and duplicated here to avoid confusion.
+
+#include <sycl/sycl.hpp>
+#include <algorithm>
+#include <iostream>
+
+using namespace sycl;
+
+int main() {
+  queue Q;
+
+  const size_t N = 32;
+  const size_t M = 4;
+
+  int* data = malloc_shared<int>(N, Q);
+  std::fill(data, data + N, 0);
+
+  Q.parallel_for(N, [=](id<1> i) {
+     int j = i % M;
+     atomic_ref<int, memory_order::relaxed, memory_scope::system,
+                access::address_space::global_space> atomic_data(data[j]);
+     atomic_data += 1;
+   }).wait();
+
+  for (int i = 0; i < N; ++i) {
+    std::cout << "data [" << i << "] = " << data[i] << "\n";
+  }
+  bool passed = true;
+  int* gold = (int*) malloc(N * sizeof(int));
+  std::fill(gold, gold + N, 0);
+  for (int i = 0; i < N; ++i) {
+    int j = i % M;
+    gold[j] += 1;
+  }
+  for (int i = 0; i < N; ++i) {
+    if (data[i] != gold[i]) {
+      passed = false;
+    }
+  }
+  std::cout << ((passed) ? "SUCCESS\n" : "FAILURE\n");
+  free(gold);
+  free(data, Q);
+  return (passed) ? 0 : 1;
+}


### PR DESCRIPTION
The book reproduces the same snippet as both Figure 19-7 and 19-17, first to introduce the concept of atomics, and second to demonstrate the usage of atomic_ref with USM.

The fact that 19-17 was "missing" from the repository was reported by readers as an error, and duplicating the source file may reduce confusion. We tried adding a symbolic link, but this caused issues on Windows.