### PR TITLE
Use group::leader() where appropriate

### DIFF
--- a/samples/Ch14_common_parallel_patterns/fig_14_17_nd_range_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_17_nd_range_reduction.cpp
@@ -20,8 +20,9 @@ int main() {
 
   Q.parallel_for(nd_range<1>{N, B}, [=](nd_item<1> it) {
      int i = it.get_global_id(0);
-     int group_sum = reduce_over_group(it.get_group(), data[i], plus<>());
-     if (it.get_local_id(0) == 0) {
+     auto grp = it.get_group();
+     int group_sum = reduce_over_group(grp, data[i], plus<>());
+     if (grp.leader()) {
        atomic_ref<
            int,
            memory_order::relaxed,


### PR DESCRIPTION
SYCL 2020 added a leader() function to the group and sub-group classes, which can be used to replace common "id == 0" checks. There were two such checks in some later chapters; we should encourage the usage of leader() instead.