### PR TITLE
add a missing copyright and license header

### DIFF
--- a/samples/Ch21_migrating_from_cuda/fig_21_4-6_walkorder.cu
+++ b/samples/Ch21_migrating_from_cuda/fig_21_4-6_walkorder.cu
@@ -1,3 +1,7 @@
+// Copyright (C) 2023 Intel Corporation
+
+// SPDX-License-Identifier: MIT
+
 #include <cuda_runtime.h>
 #include <cooperative_groups.h>
 


### PR DESCRIPTION
fig_21_4-6_walkorder.cu did not have a copyright and license header.