### PR TITLE
Fixed fig_16_12_forward_dep sample code using sgsize=16 for PVC

### DIFF
--- a/samples/Ch16_cpus/fig_16_12_forward_dep.cpp
+++ b/samples/Ch16_cpus/fig_16_12_forward_dep.cpp
@@ -8,7 +8,7 @@
 using namespace sycl;
 
 int main() {
-  const int n = 16, w = 8;
+  const int n = 16, w = 16;
 
   queue Q;
   range<2> G = {n, w};


### PR DESCRIPTION
Fixed fig_16_12_forward_dep sample code using subgroup 16 for PVC , as PVC does not support SIMD8 kernel launch.
