### PR TITLE
Remove hard-coded sub-group sizes from Ch14

### DIFF
--- a/samples/Ch14_common_parallel_patterns/fig_14_24_local_pack.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_24_local_pack.cpp
@@ -40,12 +40,11 @@ int main() {
   range<2> local(1, 8);
   Q.parallel_for(
        nd_range<2>(global, local),
-       [=](nd_item<2> it)
-           [[intel::reqd_sub_group_size(8)]] {
+       [=](nd_item<2> it) {
              int i = it.get_global_id(0);
              sub_group sg = it.get_sub_group();
              int sglid = sg.get_local_id()[0];
-             int sgrange = sg.get_max_local_range()[0];
+             int sgrange = sg.get_local_range()[0];
 
              uint32_t k = 0;
              for (int j = sglid; j < N; j += sgrange) {

--- a/samples/Ch14_common_parallel_patterns/fig_14_26_local_unpack.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_26_local_unpack.cpp
@@ -90,7 +90,7 @@ int main() {
   Q.parallel_for(
        nd_range<2>(global, local),
        [=
-  ](nd_item<2> it) [[intel::reqd_sub_group_size(8)]] {
+  ](nd_item<2> it) {
          const uint32_t j = it.get_global_id(0);
          sub_group sg = it.get_sub_group();
 
@@ -101,7 +101,7 @@ int main() {
          // Initially each work-item in the sub-group works
          // on contiguous values
          uint32_t i = iq + sg.get_local_id()[0];
-         iq += sg.get_max_local_range()[0];
+         iq += sg.get_local_range()[0];
 
          // Initialize the iterator variables
          uint32_t count;


### PR DESCRIPTION
Removing `[[sycl::reqd_sub_group_size(8)]]` makes these samples portable across devices (since a sub-group size of 8 is not guaranteed to be supported).

Making this change requires replacing calls to `get_max_local_range()` with `get_local_range()` to correctly handle cases where the maximum sub-group size is larger than the number of work-items in the work-group.