### PR TITLE
modify TEMPORARY_FIX samples to simplify the preprocessor

### DIFF
--- a/samples/Ch10_defining_kernels/fig_10_3_optional_kernel_lambda_elements.cpp
+++ b/samples/Ch10_defining_kernels/fig_10_3_optional_kernel_lambda_elements.cpp
@@ -39,16 +39,19 @@ int main() {
           [[sycl::reqd_work_group_size(1, 1, 8)]]
               ->void {
                 auto i = _i[2];
+                data_acc[i] = data_acc[i] + 1;
+              });
+    });
 #else
       h.parallel_for(
           nd_range{{size}, {8}},
           [=](id<1> i) noexcept
           [[sycl::reqd_work_group_size(8)]]
               ->void {
-#endif
                 data_acc[i] = data_acc[i] + 1;
               });
     });
+#endif
     // END CODE SNIP
   }
 


### PR DESCRIPTION
This can result in better syntax highlighting in some cases.