### PR TITLE
minor cmake updates for recent compilers

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -18,8 +18,8 @@ function(add_book_sample)
     add_executable(${BOOK_SAMPLE_TARGET} ${BOOK_SAMPLE_SOURCES})
 
     if(WITHCUDA)
-        set(BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS ${BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS} -fsycl-targets=spir64,nvptx64-nvidia-cuda)
-        set(BOOK_SAMPLE_LIBS ${BOOK_SAMPLE_LIBS} -fsycl-targets=spir64,nvptx64-nvidia-cuda)
+        set(BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS ${BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS} -fsycl-targets=nvptx64-nvidia-cuda,spir64)
+        set(BOOK_SAMPLE_LIBS ${BOOK_SAMPLE_LIBS} -fsycl-targets=nvptx64-nvidia-cuda,spir64)
     endif()
 
     target_compile_options(${BOOK_SAMPLE_TARGET} PRIVATE -fsycl -fsycl-unnamed-lambda -ferror-limit=1 -Wall -Wpedantic ${BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS})


### PR DESCRIPTION
Current compilers are failing when compiling with CUDA support when the spir64 target is listed before the nvptx64-nvidia-cuda target.  Swapping the targets works, so switch the order as a workaround while this problem is debugged.