### PR TITLE
Fix typo in load/store interfaces

### DIFF
--- a/samples/Ch11_vectors_and_math_arrays/fig_11_3.hpp
+++ b/samples/Ch11_vectors_and_math_arrays/fig_11_3.hpp
@@ -6,7 +6,7 @@
 // snippets that are not set up to be compiled as is.
 
 template <access::address_space AddressSpace, access::decorated IsDecorated> 
-  void load(size_t offset, multi_ptr ptr<DataT, AddressSpace, IsDecorated> ptr);
+  void load(size_t offset, multi_ptr<DataT, AddressSpace, IsDecorated> ptr);
 
 template <access::address_space addressSpace, access::decorated IsDecorated>
-  void store(size_t offset, multi_ptr ptr<DataT, AddressSpace, IsDecorated> ptr) const;
+  void store(size_t offset, multi_ptr<DataT, AddressSpace, IsDecorated> ptr) const;


### PR DESCRIPTION
"multi_ptr ptr" should just be "multi_ptr".