### PR TITLE
switch to device scope atomics

### DIFF
--- a/samples/Ch14_common_parallel_patterns/fig_14_18_basic_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_18_basic_reduction.cpp
@@ -20,7 +20,7 @@ int main() {
   // BEGIN CODE SNIP
   q.parallel_for(N, [=](id<1> i) {
      atomic_ref<int, memory_order::relaxed,
-                memory_scope::system,
+                memory_scope::device,
                 access::address_space::global_space>(
          *sum) += data[i];
    }).wait();

--- a/samples/Ch14_common_parallel_patterns/fig_14_19_nd_range_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_19_nd_range_reduction.cpp
@@ -26,7 +26,7 @@ int main() {
          reduce_over_group(grp, data[i], plus<>());
      if (grp.leader()) {
        atomic_ref<int, memory_order::relaxed,
-                  memory_scope::system,
+                  memory_scope::device,
                   access::address_space::global_space>(
            *sum) += group_sum;
      }

--- a/samples/Ch19_memory_model_and_atomics/fig_19_15_buffer_and_atomic_ref.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_15_buffer_and_atomic_ref.cpp
@@ -25,7 +25,7 @@ int main() {
       h.parallel_for(N, [=](id<1> i) {
         int j = i % M;
         atomic_ref<int, memory_order::relaxed,
-                   memory_scope::system,
+                   memory_scope::device,
                    access::address_space::global_space>
             atomic_acc(acc[j]);
         atomic_acc += 1;

--- a/samples/Ch19_memory_model_and_atomics/fig_19_16_usm_and_atomic_ref.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_16_usm_and_atomic_ref.cpp
@@ -26,7 +26,7 @@ int main() {
   q.parallel_for(N, [=](id<1> i) {
      int j = i % M;
      atomic_ref<int, memory_order::relaxed,
-                memory_scope::system,
+                memory_scope::device,
                 access::address_space::global_space>
          atomic_data(data[j]);
      atomic_data += 1;

--- a/samples/Ch19_memory_model_and_atomics/fig_19_17_histogram.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_17_histogram.cpp
@@ -72,7 +72,7 @@ int main() {
            // global memory
            for (int32_t b = it.get_local_id(0); b < B;
                 b += it.get_local_range(0)) {
-             atomic_ref<uint32_t, memory_order::relaxed, memory_scope::system,
+             atomic_ref<uint32_t, memory_order::relaxed, memory_scope::device,
                         access::address_space::global_space>(histogram[b]) +=
                  local[b];
            }

--- a/samples/Ch19_memory_model_and_atomics/fig_19_7_avoid_data_race_with_atomics.cpp
+++ b/samples/Ch19_memory_model_and_atomics/fig_19_7_avoid_data_race_with_atomics.cpp
@@ -21,7 +21,7 @@ int main() {
   q.parallel_for(N, [=](id<1> i) {
      int j = i % M;
      atomic_ref<int, memory_order::relaxed,
-                memory_scope::system,
+                memory_scope::device,
                 access::address_space::global_space>
          atomic_data(data[j]);
      atomic_data += 1;


### PR DESCRIPTION
Not all devices support system scope atomics.  Since we are not synchronizing across the device and the host, these samples can use device scope atomics instead.