### PR TITLE
remove the TEMPORARY_FIX as it is no longer needed

### DIFF
--- a/samples/Ch10_defining_kernels/fig_10_3_optional_kernel_lambda_elements.cpp
+++ b/samples/Ch10_defining_kernels/fig_10_3_optional_kernel_lambda_elements.cpp
@@ -7,8 +7,6 @@
 #include <sycl/sycl.hpp>
 using namespace sycl;
 
-#define TEMPORARY_FIX
-
 int main() {
   constexpr size_t size = 16;
   std::array<int, size> data;
@@ -30,19 +28,6 @@ int main() {
       // BEGIN CODE SNIP
       accessor data_acc{data_buf, h};
 
-#ifdef TEMPORARY_FIX
-      // TEMPORARY FIX: for a bug with a 1D
-      // reqd_work_group_size.
-      h.parallel_for(
-          nd_range<3>{{1, 1, size}, {1, 1, 8}},
-          [=](id<3> _i) noexcept
-          [[sycl::reqd_work_group_size(1, 1, 8)]]
-              ->void {
-                auto i = _i[2];
-                data_acc[i] = data_acc[i] + 1;
-              });
-    });
-#else
       h.parallel_for(
           nd_range{{size}, {8}},
           [=](id<1> i) noexcept
@@ -51,7 +36,6 @@ int main() {
                 data_acc[i] = data_acc[i] + 1;
               });
     });
-#endif
     // END CODE SNIP
   }
 

--- a/samples/Ch10_defining_kernels/fig_10_7_optional_kernel_functor_elements.cpp
+++ b/samples/Ch10_defining_kernels/fig_10_7_optional_kernel_functor_elements.cpp
@@ -7,26 +7,14 @@
 #include <sycl/sycl.hpp>
 using namespace sycl;
 
-#define TEMPORARY_FIX
-
 // BEGIN CODE SNIP
 class AddWithAttribute {
  public:
   AddWithAttribute(accessor<int> acc) : data_acc(acc) {}
-#ifdef TEMPORARY_FIX
-  // TEMPORARY FIX: for a bug with a 1D
-  // reqd_work_group_size.
-  [[sycl::reqd_work_group_size(1, 1, 8)]] void operator()(
-      id<3> _i) const {
-    auto i = _i[2];
-    data_acc[i] = data_acc[i] + 1;
-  }
-#else
   [[sycl::reqd_work_group_size(8)]] void operator()(
       id<1> i) const {
     data_acc[i] = data_acc[i] + 1;
   }
-#endif
 
  private:
   accessor<int> data_acc;
@@ -35,21 +23,10 @@ class AddWithAttribute {
 class MulWithAttribute {
  public:
   MulWithAttribute(accessor<int> acc) : data_acc(acc) {}
-#ifdef TEMPORARY_FIX
-  // TEMPORARY FIX: for a bug with a 1D
-  // reqd_work_group_size.
-  void operator()
-      [[sycl::reqd_work_group_size(1, 1,
-                                   8)]] (id<3> _i) const {
-    auto i = _i[2];
-    data_acc[i] = data_acc[i] * 2;
-  }
-#else
   void operator()
       [[sycl::reqd_work_group_size(8)]] (id<1> i) const {
     data_acc[i] = data_acc[i] * 2;
   }
-#endif
 
  private:
   accessor<int> data_acc;
@@ -75,27 +52,15 @@ int main() {
 
     q.submit([&](handler& h) {
       accessor data_acc{data_buf, h};
-#ifdef TEMPORARY_FIX
-      h.parallel_for(nd_range<3>{{1, 1, size}, {1, 1, 8}},
-                     AddWithAttribute(data_acc));
-    });
-#else
       h.parallel_for(nd_range{{size}, {8}},
                      AddWithAttribute(data_acc));
     });
-#endif
 
     q.submit([&](handler& h) {
       accessor data_acc{data_buf, h};
-#ifdef TEMPORARY_FIX
-      h.parallel_for(nd_range<3>{{1, 1, size}, {1, 1, 8}},
-                     MulWithAttribute(data_acc));
-    });
-#else
       h.parallel_for(nd_range{{size}, {8}},
                      MulWithAttribute(data_acc));
     });
-#endif
   }
 
   for (int i = 0; i < size; i++) {


### PR DESCRIPTION
The "TEMPORARY_FIX" that was previously included in fig_10_3 and fig_10_7 is no longer needed.  Tested with the v2023.2 compiler.