### PR TITLE
compile CUDA for sm_60 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,13 @@ option(NODPCT   "Disable samples that require the DPC++ Compatibility Tool (dpct
 option(NOL0     "Disable samples that require the oneAPI Level Zero Headers and Loader." ON)
 option(WITHCUDA "Enable CUDA device support for the samples.")
 
+set(CUDA_GPU_ARCH "sm_60" CACHE STRING "CUDA GPUs to compile for.")
+if (WITHCUDA)
+    mark_as_advanced(CLEAR FORCE CUDA_GPU_ARCH)
+else()
+    mark_as_advanced(FORCE CUDA_GPU_ARCH)
+endif()
+
 enable_testing()
 
 add_subdirectory(samples)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -18,8 +18,8 @@ function(add_book_sample)
     add_executable(${BOOK_SAMPLE_TARGET} ${BOOK_SAMPLE_SOURCES})
 
     if(WITHCUDA)
-        set(BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS ${BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS} -fsycl-targets=nvptx64-nvidia-cuda,spir64 -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60)
-        set(BOOK_SAMPLE_LIBS ${BOOK_SAMPLE_LIBS} -fsycl-targets=nvptx64-nvidia-cuda,spir64 -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60)
+        set(BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS ${BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS} -fsycl-targets=nvptx64-nvidia-cuda,spir64 -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=${CUDA_GPU_ARCH})
+        set(BOOK_SAMPLE_LIBS ${BOOK_SAMPLE_LIBS} -fsycl-targets=nvptx64-nvidia-cuda,spir64 -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=${CUDA_GPU_ARCH})
     endif()
 
     target_compile_options(${BOOK_SAMPLE_TARGET} PRIVATE -fsycl -fsycl-unnamed-lambda -ferror-limit=1 -Wall -Wpedantic ${BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS})

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -18,8 +18,8 @@ function(add_book_sample)
     add_executable(${BOOK_SAMPLE_TARGET} ${BOOK_SAMPLE_SOURCES})
 
     if(WITHCUDA)
-        set(BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS ${BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS} -fsycl-targets=nvptx64-nvidia-cuda,spir64)
-        set(BOOK_SAMPLE_LIBS ${BOOK_SAMPLE_LIBS} -fsycl-targets=nvptx64-nvidia-cuda,spir64)
+        set(BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS ${BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS} -fsycl-targets=nvptx64-nvidia-cuda,spir64 -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60)
+        set(BOOK_SAMPLE_LIBS ${BOOK_SAMPLE_LIBS} -fsycl-targets=nvptx64-nvidia-cuda,spir64 -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60)
     endif()
 
     target_compile_options(${BOOK_SAMPLE_TARGET} PRIVATE -fsycl -fsycl-unnamed-lambda -ferror-limit=1 -Wall -Wpedantic ${BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS})


### PR DESCRIPTION
This PR adds the ability to specify which sm version to compile for via a CMake variable.  By default, it compiles for sm_60.  This is needed to successfully execute some of the samples, which use system atomics, and are only available for newer sm versions.