### PR TITLE
fix chapter 10 examples for nd_range parallel_fors

### DIFF
--- a/samples/Ch10_defining_kernels/fig_10_3_optional_kernel_lambda_elements.cpp
+++ b/samples/Ch10_defining_kernels/fig_10_3_optional_kernel_lambda_elements.cpp
@@ -30,11 +30,11 @@ int main() {
 
       h.parallel_for(
           nd_range{{size}, {8}},
-          [=](id<1> i) noexcept
-          [[sycl::reqd_work_group_size(8)]]
-              ->void {
-                data_acc[i] = data_acc[i] + 1;
-              });
+          [=](nd_item<1> item) noexcept
+          [[sycl::reqd_work_group_size(8)]] -> void {
+            auto i = item.get_global_id();
+            data_acc[i] = data_acc[i] + 1;
+          });
     });
     // END CODE SNIP
   }

--- a/samples/Ch10_defining_kernels/fig_10_7_optional_kernel_functor_elements.cpp
+++ b/samples/Ch10_defining_kernels/fig_10_7_optional_kernel_functor_elements.cpp
@@ -12,7 +12,8 @@ class AddWithAttribute {
  public:
   AddWithAttribute(accessor<int> acc) : data_acc(acc) {}
   [[sycl::reqd_work_group_size(8)]] void operator()(
-      id<1> i) const {
+      nd_item<1> item) const {
+    auto i = item.get_global_id();
     data_acc[i] = data_acc[i] + 1;
   }
 
@@ -23,8 +24,9 @@ class AddWithAttribute {
 class MulWithAttribute {
  public:
   MulWithAttribute(accessor<int> acc) : data_acc(acc) {}
-  void operator()
-      [[sycl::reqd_work_group_size(8)]] (id<1> i) const {
+  void operator() [[sycl::reqd_work_group_size(8)]] (
+      nd_item<1> item) const {
+    auto i = item.get_global_id();
     data_acc[i] = data_acc[i] * 2;
   }
 

--- a/second_edition_errata.txt
+++ b/second_edition_errata.txt
@@ -1,7 +1,12 @@
 Errata for the Second Edition
 
 The following are known issues contained in the book
-Data Parallel C++: Programming Acclerated Systems using C++ and SYCL
+Data Parallel C++: Programming Accelerated Systems using C++ and SYCL
 by James Reinders, Ben Ashbaugh, James Brodman, Michael Kinsner, John Pennycook, Xinmin Tian (Apress, 2023/2024).
 
-None for the moment.
+p.252 - Figure 10-3: Because this is an nd_range parallel_for, the argument to
+the kernel lambda expression must be an nd_item, not an id.
+
+p.258 - Figure 10-7: Because these functors are used by an nd_range
+parallel_for, the argument to the overloaded function call operator() must be an
+nd_item, not an id.


### PR DESCRIPTION
The two chapter 10 examples showing optional kernel elements need to use an nd_range parallel_for because they are including an optional required work group size attribute, but this also means that they need to operate on an nd_item rather than an item.

This requirement is not currently enforced by all SYCL compilers, though it is enforced by some SYCL compilers, and it is required by the spec.