### PR TITLE
disable fig_19_18-19_device_latch testing

### DIFF
--- a/samples/Ch19_memory_model_and_atomics/CMakeLists.txt
+++ b/samples/Ch19_memory_model_and_atomics/CMakeLists.txt
@@ -32,6 +32,5 @@ add_book_sample(
     SOURCES fig_19_17_histogram.cpp)
 
 add_book_sample(
-    TEST
     TARGET fig_19_18-19_device_latch
     SOURCES fig_19_18-19_device_latch.cpp)


### PR DESCRIPTION
This test requires forward progress guarantees that are not provided by every SYCL device, so it may not run consistently, and may even hang on some devices.