### PR TITLE
switch from std::array to std::vector to avoid large stack allocation

### DIFF
--- a/samples/Ch21_migrating_cuda_code/fig_21_10_reverse.cu
+++ b/samples/Ch21_migrating_cuda_code/fig_21_10_reverse.cu
@@ -4,9 +4,9 @@
 
 #include <cuda_runtime.h>
 
-#include <array>
 #include <iostream>
 #include <numeric>
+#include <vector>
 
 constexpr size_t size = 1024 * 1024;
 
@@ -22,7 +22,7 @@ __global__ void Reverse(int* ptr, size_t size) {
 }
 
 int main() {
-  std::array<int, size> data;
+  std::vector<int> data(size);
   std::iota(data.begin(), data.end(), 0);
 
   cudaDeviceProp deviceProp;

--- a/samples/Ch21_migrating_cuda_code/fig_21_13-14_reverse_migrated.cpp
+++ b/samples/Ch21_migrating_cuda_code/fig_21_13-14_reverse_migrated.cpp
@@ -2,11 +2,11 @@
 
 // SPDX-License-Identifier: MIT
 
-#include <array>
 #include <dpct/dpct.hpp>
 #include <iostream>
 #include <numeric>
 #include <sycl/sycl.hpp>
+#include <vector>
 
 constexpr size_t size = 1024 * 1024;
 
@@ -28,7 +28,7 @@ void Reverse(int *ptr, size_t size,
 int main() try {
   dpct::device_ext &dev_ct1 = dpct::get_current_device();
   sycl::queue &q_ct1 = dev_ct1.default_queue();
-  std::array<int, size> data;
+  std::vector<int> data(size);
   std::iota(data.begin(), data.end(), 0);
 
   // BEGIN CODE SNIP


### PR DESCRIPTION
Switch from a std::array (stack allocation) to a std::vector (heap allocation) to avoid a large stack allocation.  The current size can overflow the stack on some device and operating systems.