### PR TITLE
switch another sample from std::array to std::vector

### DIFF
--- a/samples/Ch13_practical_tips/fig_13_6_queue_profiling_timing.cpp
+++ b/samples/Ch13_practical_tips/fig_13_6_queue_profiling_timing.cpp
@@ -8,7 +8,7 @@ using namespace sycl;
 
 // Array type and data size for this example.
 constexpr size_t array_size = (1 << 16);
-typedef std::array<int, array_size> IntArray;
+typedef std::vector<int> IntArray;
 
 void VectorAdd(queue &q, const IntArray &a,
                const IntArray &b, IntArray &sum) {
@@ -57,7 +57,7 @@ void InitializeArray(IntArray &a) {
 }
 
 int main() {
-  IntArray a, b, sum;
+  IntArray a(array_size), b(array_size), sum(array_size);
   InitializeArray(a);
   InitializeArray(b);
 

--- a/second_edition_errata.txt
+++ b/second_edition_errata.txt
@@ -11,10 +11,13 @@ p.258 - Figure 10-7: Because these functors are used by an nd_range
 parallel_for, the argument to the overloaded function call operator() must be an
 nd_item, not an id.
 
-p. 599-602 - Figure 21-10 with impact on full code for 21-13 & 21-14.  Change "std:array" to "std:vector" as a better coding method.
-Chapter 21 - examples based on 21-10 (CUDA) and the resulting code (C++ with SYCL) 
+p. 332-333 - Figure 13-6.  Change "std::array" to "std::vector" as a better coding method.
 This example is better written using std:vector instead of std::array to avoid large stack allocation.
 On some systems (e.g., Windows), this will prevent a program failure due to stack overflow.
-Modified code for Ch21_migrating_cuda_code/fig_21_10_reverse.cu and Ch21_migrating_cuda_code/fig_21_13-14_reverse_migrated.cpp in the github repo.
-Per Issue#125: switch from std::array to std::vector to avoid large stack allocation.
+Modified code for Ch13_practical_tips/fig_13_6_queue_profiling_timing.cpp in the GitHub repo.
 
+p. 599-602 - Figure 21-10 with impact on full code for 21-13 & 21-14.  Change "std:array" to "std:vector" as a better coding method.
+Same as above, this example is better written using std:vector instead of std::array to avoid large stack allocation.
+Chapter 21 - examples based on 21-10 (CUDA) and the resulting code (C++ with SYCL)
+Modified code for Ch21_migrating_cuda_code/fig_21_10_reverse.cu and Ch21_migrating_cuda_code/fig_21_13-14_reverse_migrated.cpp in the GitHub repo.
+See Pull Request #125: switch from std::array to std::vector to avoid large stack allocation.


### PR DESCRIPTION
This avoids a large stack allocation that causes issues for some devices and operating systems.

See #125, which made a similar change in a different sample.