### PR TITLE
fix the default Level Zero device message

### DIFF
--- a/samples/Ch20_backend_interoperability/fig_20_4_level_zero_to_sycl.cpp
+++ b/samples/Ch20_backend_interoperability/fig_20_4_level_zero_to_sycl.cpp
@@ -23,8 +23,8 @@ int main(int argc, char* argv[]) {
   if (argc <= 1) {
     std::cout << "Run as ./<progname> <Level Zero driver "
                  "index> <Level Zero device index>\n";
-    std::cout << "Defaulting to the first OpenCL Level "
-                 "Zero driver and device.\n";
+    std::cout << "Defaulting to the first Level Zero "
+                 "driver and device.\n";
   }
 
   constexpr size_t size = 16;


### PR DESCRIPTION
Fixes a misleading message when choosing the default Level Zero driver and device.