### PR TITLE
fix histogram sample reduction bounds

### DIFF
--- a/samples/Ch14_common_parallel_patterns/fig_14_11_array_reduction.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_11_array_reduction.cpp
@@ -22,9 +22,9 @@ int main() {
      // BEGIN CODE SNIP
      h.parallel_for(
          range{N},
-         reduction(span<int, 16>(histogram, 16), plus<>()),
+         reduction(span<int, B>(histogram, B), plus<>()),
          [=](id<1> i, auto& histogram) {
-           histogram[i % B]++;
+           histogram[data[i] % B]++;
          });
      // END CODE SNIP
    }).wait();

--- a/second_edition_errata.txt
+++ b/second_edition_errata.txt
@@ -16,6 +16,10 @@ This example is better written using std:vector instead of std::array to avoid l
 On some systems (e.g., Windows), this will prevent a program failure due to stack overflow.
 Modified code for Ch13_practical_tips/fig_13_6_queue_profiling_timing.cpp in the GitHub repo.
 
+p. 365 - Figure 14-11: The histogram has B bins, so the reduction should be over B elements and
+not over 16 elements.  Additionally, the sample should read the data to histogram from the "data"
+array rather than reading the id "i".
+
 p. 599-602 - Figure 21-10 with impact on full code for 21-13 & 21-14.  Change "std:array" to "std:vector" as a better coding method.
 Same as above, this example is better written using std:vector instead of std::array to avoid large stack allocation.
 Chapter 21 - examples based on 21-10 (CUDA) and the resulting code (C++ with SYCL)


### PR DESCRIPTION
fixes #128 

The histogram has B bins, where B is equal to four, so the reduction should not be over 16 elements.