### PR TITLE
fix ambiguous call to sqrt in fig_14_15_map

### DIFF
--- a/samples/Ch14_common_parallel_patterns/fig_14_15_map.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_15_map.cpp
@@ -22,7 +22,7 @@ int main() {
   // BEGIN CODE SNIP
   // Compute the square root of each input value
   q.parallel_for(N, [=](id<1> i) {
-     output[i] = sqrt(input[i]);
+     output[i] = sycl::sqrt(input[i]);
    }).wait();
   // END CODE SNIP
 

--- a/second_edition_errata.txt
+++ b/second_edition_errata.txt
@@ -16,6 +16,9 @@ This example is better written using std:vector instead of std::array to avoid l
 On some systems (e.g., Windows), this will prevent a program failure due to stack overflow.
 Modified code for Ch13_practical_tips/fig_13_6_queue_profiling_timing.cpp in the GitHub repo.
 
+p. 371 - Figure 14-15: Need to add "sycl::" to the call to "sqrt" to disambiguate which function to call.
+Without the explicit namespace the call could be to "sycl::sqrt" or to "std::sqrt".
+
 p. 599-602 - Figure 21-10 with impact on full code for 21-13 & 21-14.  Change "std:array" to "std:vector" as a better coding method.
 Same as above, this example is better written using std:vector instead of std::array to avoid large stack allocation.
 Chapter 21 - examples based on 21-10 (CUDA) and the resulting code (C++ with SYCL)


### PR DESCRIPTION
Need to add an explicit sycl:: namespace to the call to sqrt, to disambiguate between sycl::sqrt and std::sqrt.