### PR TITLE
add missing cstdlib include to matrix multiplication harness

### DIFF
--- a/samples/Ch09_communication_and_sychronization/matmul_harness.cpp
+++ b/samples/Ch09_communication_and_sychronization/matmul_harness.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <algorithm>
+#include <cstdlib>
 #include <iostream>
 #include <sycl/sycl.hpp>
 using namespace sycl;
@@ -93,7 +94,7 @@ int main() {
                 seconds /
                 1e9;
   std::cout << "Success!\n";
-  std::cout << "GFlops: " << gflops << std::endl;
+  std::cout << "GFlops: " << gflops << "\n";
 
   return 0;
 }

--- a/samples/Ch15_programming_for_gpus/matrix_multiplication_harness.cpp
+++ b/samples/Ch15_programming_for_gpus/matrix_multiplication_harness.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <algorithm>
+#include <cstdlib>
 #include <iostream>
 #include <sycl/sycl.hpp>
 using namespace sycl;


### PR DESCRIPTION
The matrix multiplication harness calls std::fabs so it needs to include cstdlib or cmath and cannot rely on these files being included implicitly.