### PR TITLE
fix a few more ambiguous function calls

### DIFF
--- a/samples/Ch14_common_parallel_patterns/fig_14_20-22_inclusive_scan.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_20-22_inclusive_scan.cpp
@@ -41,7 +41,7 @@ int main() {
        group_barrier(it.get_group());
 
        // Perform inclusive scan in local memory
-       for (int32_t d = 0; d <= log2((float)L) - 1; ++d) {
+       for (int32_t d = 0; d <= sycl::log2((float)L) - 1; ++d) {
          uint32_t stride = (1 << d);
          int32_t update =
              (li >= stride) ? local[li - stride] : 0;
@@ -74,7 +74,7 @@ int main() {
        group_barrier(it.get_group());
 
        // Perform inclusive scan in local memory
-       for (int32_t d = 0; d <= log2((float)G) - 1; ++d) {
+       for (int32_t d = 0; d <= sycl::log2((float)G) - 1; ++d) {
          uint32_t stride = (1 << d);
          int32_t update =
              (li >= stride) ? local[li - stride] : 0;

--- a/samples/Ch14_common_parallel_patterns/fig_14_26_local_unpack.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_26_local_unpack.cpp
@@ -72,7 +72,7 @@ int main() {
   params.xc = 0.0f;
   params.yc = 0.0f;
   params.zoom = 1.0f;
-  params.zoom_px = pow(2.0f, 3.0f - params.zoom) * 1e-3f;
+  params.zoom_px = std::pow(2.0f, 3.0f - params.zoom) * 1e-3f;
   params.x_span = Nx * params.zoom_px;
   params.y_span = Ny * params.zoom_px;
   params.x0 = params.xc - params.x_span * 0.5f;
@@ -116,7 +116,7 @@ int main() {
        if (any_of_group(sg, converged)) {
          // Replace pixels that have converged using an
          // unpack. Pixels that haven't converged are not
-	 // replaced.
+         // replaced.
          uint32_t index = exclusive_scan_over_group(
              sg, converged, plus<>());
          i = (converged) ? iq + index : i;

--- a/second_edition_errata.txt
+++ b/second_edition_errata.txt
@@ -23,6 +23,9 @@ array rather than reading the id "i".
 p. 371 - Figure 14-15: Need to add "sycl::" to the call to "sqrt" to disambiguate which function to call.
 Without the explicit namespace the call could be to "sycl::sqrt" or to "std::sqrt".
 
+p. 375 - Figure 24-20: Need to add "sycl::" to the call to "log2" to disambiguate which function to call.
+Without the explicit namespace the call could be to "sycl::log2" or to "std::log2".
+
 p. 599-602 - Figure 21-10 with impact on full code for 21-13 & 21-14.  Change "std:array" to "std:vector" as a better coding method.
 Same as above, this example is better written using std:vector instead of std::array to avoid large stack allocation.
 Chapter 21 - examples based on 21-10 (CUDA) and the resulting code (C++ with SYCL)


### PR DESCRIPTION
Similar to #130, this fixes a few more ambiguous function calls by adding an explicit `std::` or `sycl::` namespace.