### PR TITLE
include cmath not cstdlib for std::fabs

### DIFF
--- a/samples/Ch09_communication_and_sychronization/matmul_harness.cpp
+++ b/samples/Ch09_communication_and_sychronization/matmul_harness.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <algorithm>
-#include <cstdlib>
+#include <cmath>
 #include <iostream>
 #include <sycl/sycl.hpp>
 using namespace sycl;

--- a/samples/Ch11_vectors_and_math_arrays/fig_11_7_vector_exec.cpp
+++ b/samples/Ch11_vectors_and_math_arrays/fig_11_7_vector_exec.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <array>
+#include <cmath>
 #include <sycl/sycl.hpp>
 using namespace sycl;
 

--- a/samples/Ch14_common_parallel_patterns/fig_14_15_map.cpp
+++ b/samples/Ch14_common_parallel_patterns/fig_14_15_map.cpp
@@ -4,7 +4,7 @@
 
 #include <algorithm>
 #include <cstdio>
-#include <cstdlib>
+#include <cmath>
 #include <numeric>
 #include <sycl/sycl.hpp>
 

--- a/samples/Ch15_programming_for_gpus/matrix_multiplication_harness.cpp
+++ b/samples/Ch15_programming_for_gpus/matrix_multiplication_harness.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <algorithm>
-#include <cstdlib>
+#include <cmath>
 #include <iostream>
 #include <sycl/sycl.hpp>
 using namespace sycl;


### PR DESCRIPTION
The `<cstdlib>` include only has support for std::abs, not for std::fabs. The `<cmath>` include has both, so we should include it instead.

https://en.cppreference.com/w/cpp/numeric/math/fabs