### PR TITLE
enable ROCm as the compile target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,12 +34,25 @@ option(NODPL    "Disable samples that require the oneAPI DPC++ Library (oneDPL).
 option(NODPCT   "Disable samples that require the DPC++ Compatibility Tool (dpct).")
 option(NOL0     "Disable samples that require the oneAPI Level Zero Headers and Loader." ON)
 option(WITHCUDA "Enable CUDA device support for the samples.")
+option(WITHROCM "Enable ROCm device support for the samples.")
+
+if (WITHCUDA AND WITHROCM)
+    message(FATAL_ERROR "WITHCUDA and WITHROCM cannot be enabled at the same time.\n" 
+    "Clean up the directory and try again with only one of them enabled.")
+endif()
 
 set(CUDA_GPU_ARCH "sm_60" CACHE STRING "CUDA GPUs to compile for.")
 if (WITHCUDA)
     mark_as_advanced(CLEAR FORCE CUDA_GPU_ARCH)
 else()
     mark_as_advanced(FORCE CUDA_GPU_ARCH)
+endif()
+
+set(ROCM_GPU_ARCH "gfx1100" CACHE STRING "ROCm GPUs to compile for.")
+if (WITHROCM)
+    mark_as_advanced(CLEAR FORCE ROCM_GPU_ARCH)
+else()
+    mark_as_advanced(FORCE ROCM_GPU_ARCH)
 endif()
 
 enable_testing()

--- a/README.md
+++ b/README.md
@@ -107,3 +107,26 @@ See your CMake documentation for more details.
 | NODPCT | BOOL | Disable samples that require the DPC++ Compatibility Tool (dpct).  Default: `FALSE`
 | NOL0 | BOOL | Disable samples that require the oneAPI Level Zero Headers and Loader.  Default: `TRUE`
 | WITHCUDA | BOOL | Enable CUDA device support for the samples.  Default: `FALSE`
+| WITHROCM | BOOL | Enable ROCm device support for the samples.  Default: `FALSE`
+
+## NVIDIA/ROCm Device Support
+
+> **Note**: 
+> Currently, `fig_17_31_inter_kernel_pipe` is disabled for NVIDIA/ROCm devices, as they are not supported.
+
+You can set the `WITHCUDA` or `WITHROCM` variable to build for CUDA or ROCM devices. For example, for a CUDA device:
+
+```sh
+cmake -G "Unix Makefiles" .. -DWITHCUDA=ON
+```
+
+or for a ROCM device:
+
+```sh
+cmake -G "Unix Makefiles" .. -DWITHROCM=ON
+```
+
+You can also set the target GPU architecture (which is necessary for ROCm devices and set to `gfx1100` by default) like:
+```sh
+cmake -G "Unix Makefiles" .. -DWITHROCM=ON -DROCM_GPU_ARCH=gfx1030
+```

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -22,6 +22,11 @@ function(add_book_sample)
         set(BOOK_SAMPLE_LIBS ${BOOK_SAMPLE_LIBS} -fsycl-targets=nvptx64-nvidia-cuda,spir64 -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=${CUDA_GPU_ARCH})
     endif()
 
+    if(WITHROCM)
+        set(BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS ${BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS} -fsycl-targets=amdgcn-amd-amdhsa,spir64 -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=${ROCM_GPU_ARCH})
+        set(BOOK_SAMPLE_LIBS ${BOOK_SAMPLE_LIBS} -fsycl-targets=amdgcn-amd-amdhsa,spir64 -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=${ROCM_GPU_ARCH})
+    endif()
+
     target_compile_options(${BOOK_SAMPLE_TARGET} PRIVATE -fsycl -fsycl-unnamed-lambda -ferror-limit=1 -Wall -Wpedantic ${BOOK_SAMPLE_ADDITIONAL_COMPILE_OPTIONS})
 
     target_link_libraries(${BOOK_SAMPLE_TARGET} PRIVATE ${BOOK_SAMPLE_LIBS} -fsycl)

--- a/samples/Ch17_programming_for_fpgas/CMakeLists.txt
+++ b/samples/Ch17_programming_for_fpgas/CMakeLists.txt
@@ -26,8 +26,8 @@ add_book_sample(
     TARGET fig_17_22_loop_carried_state
     SOURCES fig_17_22_loop_carried_state.cpp)
 
-if(NOT WITHCUDA)
-# TEMPORARILY DISABLE: doesn't work with CUDA backend.
+if(NOT WITHCUDA AND NOT WITHROCM)
+# TEMPORARILY DISABLE: doesn't work with CUDA or ROCm backend.
 add_book_sample(
     TARGET fig_17_31_inter_kernel_pipe
     SOURCES fig_17_31_inter_kernel_pipe.cpp)


### PR DESCRIPTION
Hi, thank you for the great work!
I'm now using ROCm system, so I wanted to add it to the compile target.
It's just a few lines of additions that make "WITHROCM" works in a similar way to "WITHCUDA."
Could you check it if it would be appropriate to merge this to the main branch?